### PR TITLE
do not use the sum.golang.org service, too many 410s

### DIFF
--- a/library.sh
+++ b/library.sh
@@ -512,6 +512,7 @@ function go_update_deps() {
 
   export GO111MODULE=on
   export GOFLAGS=""
+  export GOSUMDB=off   # Do not use the sum.golang.org service.
 
   echo "=== Update Deps for Golang"
 


### PR DESCRIPTION
We are still getting a lot of 410's when doing update deps, we are using direct go mod mode, but there is a second checksum service that is also in-play. Removing that service.

Ref: https://twitter.com/mattomata/status/1323296883838627840