### PR TITLE
chore: filter out bogus warnings about symlinks when doing a go mod tidy

### DIFF
--- a/library.sh
+++ b/library.sh
@@ -554,8 +554,11 @@ function go_update_deps() {
   echo "--- Go mod tidy and vendor"
 
   # Prune modules.
+  local orig_pipefail_opt=$(shopt -p -o pipefail)
+  set -o pipefail
   go mod tidy 2>&1 | grep -v "ignoring symlink" || true
   go mod vendor 2>&1 |  grep -v "ignoring symlink" || true
+  eval "$orig_pipefail_opt"
 
   echo "--- Removing unwanted vendor files"
 

--- a/library.sh
+++ b/library.sh
@@ -554,8 +554,8 @@ function go_update_deps() {
   echo "--- Go mod tidy and vendor"
 
   # Prune modules.
-  go mod tidy
-  go mod vendor
+  go mod tidy 2>&1 | grep -v "ignoring symlink" || true
+  go mod vendor 2>&1 |  grep -v "ignoring symlink" || true
 
   echo "--- Removing unwanted vendor files"
 


### PR DESCRIPTION
This PR shuts up spurious warnings in the client build, but still
let through other warnings.