### PR TITLE
Validate usage of knative.dev/hack/shell

### DIFF
--- a/foo/caller_not_allowed_test.go
+++ b/foo/caller_not_allowed_test.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package foo_test
+
+import (
+	"errors"
+	"testing"
+
+	"knative.dev/hack/shell"
+)
+
+func TestCallerNotAllowed(t *testing.T) {
+	_, err := shell.NewProjectLocation("..")
+	if !errors.Is(err, shell.ErrCallerNotAllowed) {
+		t.Error("usage should be blocked")
+	}
+}

--- a/shell/project.go
+++ b/shell/project.go
@@ -75,5 +75,6 @@ func ensureIsValid(filename string) error {
 			return nil
 		}
 	}
-	return fmt.Errorf("%w: %s", ErrCallerNotAllowed, filename)
+	return fmt.Errorf("%w, tried using from: %s",
+		ErrCallerNotAllowed, filename)
 }

--- a/shell/project.go
+++ b/shell/project.go
@@ -18,12 +18,21 @@ package shell
 
 import (
 	"errors"
+	"fmt"
 	"path"
+	"regexp"
 	"runtime"
 )
 
-// ErrCantGetCaller is raised when we can't calculate a caller of NewProjectLocation.
-var ErrCantGetCaller = errors.New("can't get caller")
+var (
+	// ErrCantGetCaller is raised when we can't calculate a caller of NewProjectLocation.
+	ErrCantGetCaller = errors.New("can't get caller")
+
+	// ErrCallerNotAllowed is raised when user tries to use this shell-out package
+	// outside of allowed places. This package is deprecated from start and was
+	// introduced to allow rewriting of shell code to Golang in small chunks.
+	ErrCallerNotAllowed = errors.New("don't try use knative.dev/hack/shell package outside of allowed places")
+)
 
 // NewProjectLocation creates a ProjectLocation that is used to calculate
 // relative paths within the project.
@@ -31,6 +40,10 @@ func NewProjectLocation(pathToRoot string) (ProjectLocation, error) {
 	_, filename, _, ok := runtime.Caller(1)
 	if !ok {
 		return nil, ErrCantGetCaller
+	}
+	err := ensureIsValid(filename)
+	if err != nil {
+		return nil, err
 	}
 	return &callerLocation{
 		caller:     filename,
@@ -49,4 +62,18 @@ func (c *callerLocation) RootPath() string {
 type callerLocation struct {
 	caller     string
 	pathToRoot string
+}
+
+func ensureIsValid(filename string) error {
+	validPaths := []string{
+		"knative.+/test/upgrade/",
+		"knative(:?\\.dev/|-)hack/shell/",
+	}
+	for _, validPath := range validPaths {
+		r := regexp.MustCompile(validPath)
+		if loc := r.FindStringIndex(filename); loc != nil {
+			return nil
+		}
+	}
+	return fmt.Errorf("%w: %s", ErrCallerNotAllowed, filename)
 }


### PR DESCRIPTION
This is follow up to knative/hack#30 intended to disallow using this shell out package without control.

If a new place is required to use this package, an "allow PR" should be made to this repo first.

/cc @n3wscott 