### PR TITLE
Create a go path that points back to the local directory.

### DIFF
--- a/library.sh
+++ b/library.sh
@@ -578,15 +578,14 @@ function go_update_deps() {
 # Return a GOPATH to a temp directory. Works around the out-of-GOPATH issues
 # for k8s client gen mixed with go mod.
 # indended to be used like:
-#   export GOPATH=$(go_mod_path)
-function go_mod_path() {
+#   export GOPATH=$(go_mod_gopath_hack)
+function go_mod_gopath_hack() {
 	export MODULE_NAME=$(go mod graph | cut -d' ' -f 1 | grep -v '@' | head -1)
-	export TMP_DIR="$(mktemp -d)"
-	export GOPATH=${TMP_DIR}
-	export TMP_REPO_PATH="${TMP_DIR}/src/${MODULE_NAME}"
+	local TMP_DIR="$(mktemp -d)"
+	local TMP_REPO_PATH="${TMP_DIR}/src/${MODULE_NAME}"
 	mkdir -p "$(dirname "${TMP_REPO_PATH}")" && ln -s "${REPO_ROOT_DIR}" "${TMP_REPO_PATH}"
 
-	echo "$GOPATH"
+	echo "${TMP_DIR}"
 }
 
 # Run kntest tool, error out and ask users to install it if it's not currently installed.

--- a/library.sh
+++ b/library.sh
@@ -575,6 +575,20 @@ function go_update_deps() {
   remove_broken_symlinks ./vendor
 }
 
+# Return a GOPATH to a temp directory. Works around the out-of-GOPATH issues
+# for k8s client gen mixed with go mod.
+# indended to be used like:
+#   export GOPATH=$(go_mod_path)
+function go_mod_path() {
+	export MODULE_NAME=$(go mod graph | cut -d' ' -f 1 | grep -v '@' | head -1)
+	export TMP_DIR="$(mktemp -d)"
+	export GOPATH=${TMP_DIR}
+	export TMP_REPO_PATH="${TMP_DIR}/src/${MODULE_NAME}"
+	mkdir -p "$(dirname "${TMP_REPO_PATH}")" && ln -s "${REPO_ROOT_DIR}" "${TMP_REPO_PATH}"
+
+	echo "$GOPATH"
+}
+
 # Run kntest tool, error out and ask users to install it if it's not currently installed.
 # Parameters: $1..$n - parameters passed to the tool.
 function run_kntest() {

--- a/library.sh
+++ b/library.sh
@@ -580,12 +580,12 @@ function go_update_deps() {
 # indended to be used like:
 #   export GOPATH=$(go_mod_gopath_hack)
 function go_mod_gopath_hack() {
-	export MODULE_NAME=$(go mod graph | cut -d' ' -f 1 | grep -v '@' | head -1)
-	local TMP_DIR="$(mktemp -d)"
-	local TMP_REPO_PATH="${TMP_DIR}/src/${MODULE_NAME}"
-	mkdir -p "$(dirname "${TMP_REPO_PATH}")" && ln -s "${REPO_ROOT_DIR}" "${TMP_REPO_PATH}"
+  export MODULE_NAME=$(go mod graph | cut -d' ' -f 1 | grep -v '@' | head -1)
+  local TMP_DIR="$(mktemp -d)"
+  local TMP_REPO_PATH="${TMP_DIR}/src/${MODULE_NAME}"
+  mkdir -p "$(dirname "${TMP_REPO_PATH}")" && ln -s "${REPO_ROOT_DIR}" "${TMP_REPO_PATH}"
 
-	echo "${TMP_DIR}"
+  echo "${TMP_DIR}"
 }
 
 # Run kntest tool, error out and ask users to install it if it's not currently installed.


### PR DESCRIPTION
Fixes #15 

This change will provide a hook to integrate with out-of-GOPATH projects to use k8s codegen and the changes are redirected back to the module.

Example integration in https://github.com/knative-sandbox/discovery/pull/125