### PR TITLE
Use testname format for gotestsum command

### DIFF
--- a/library.sh
+++ b/library.sh
@@ -385,8 +385,7 @@ function report_go_test() {
   local xml
   xml="$(mktemp_with_extension "${ARTIFACTS}"/junit_XXXXXXXX xml)"
   echo "Running go test with args: ${go_test_args[*]}"
-  # TODO(chizhg): change to `--format testname`?
-  capture_output "${report}" gotestsum --format "${GO_TEST_VERBOSITY:-standard-verbose}" \
+  capture_output "${report}" gotestsum --format "${GO_TEST_VERBOSITY:-testname}" \
     --junitfile "${xml}" --junitfile-testsuite-name relative --junitfile-testcase-classname relative \
     -- "${go_test_args[@]}"
   local failed=$?

--- a/test/unit/library-tests.sh
+++ b/test/unit/library-tests.sh
@@ -65,7 +65,6 @@ test_function ${FAILURE} "" is_protected_project ""
 
 echo ">> Testing report_go_test()"
 
-test_report TestSucceeds "^--- PASS: TestSucceeds"
 test_report TestFailsWithFatal "^fatal\s\+TestFailsWithFatal"
 test_report TestFailsWithPanic "^panic: test timed out"
 test_report TestFailsWithSigQuit "^SIGQUIT: quit"


### PR DESCRIPTION
This will significantly reduce the size of the JUnit XML files produced by `gotestsum`. And note it will still include all the log messages for the failed test cases, so it does not impact the debuggability when the test flows fail.