### PR TITLE
Add hermetic go mod aware handling to run_go_tool

### DIFF
--- a/library.sh
+++ b/library.sh
@@ -497,7 +497,7 @@ function run_go_tool() {
     run="${run}/$2"
   fi
 
-  if [[ -z "$(go list -f '{{.Module.Version}}' $1)" ]]; then
+  if [[ -z "$(go list -mod=readonly -f '{{.Module.Version}}' $1)" ]]; then
     echo "Tool $1/$2 is not included in hack/tools.go, falling back to non-hermetic install (via GOPATH)."
     if [[ -z "$(which ${tool})" ]]; then
       local action=get

--- a/library.sh
+++ b/library.sh
@@ -490,24 +490,37 @@ function start_latest_eventing_sugar_controller() {
 function run_go_tool() {
   local tool=$2
   local install_failed=0
-  if [[ -z "$(which ${tool})" ]]; then
-    local action=get
-    [[ $1 =~ ^[\./].* ]] && action=install
-    # Avoid running `go get` from root dir of the repository, as it can change go.sum and go.mod files.
-    # See discussions in https://github.com/golang/go/issues/27643.
-    if [[ ${action} == "get" && $(pwd) == "${REPO_ROOT_DIR}" ]]; then
-      local temp_dir="$(mktemp -d)"
-      # Swallow the output as we are returning the stdout in the end.
-      pushd "${temp_dir}" > /dev/null 2>&1
-      GOFLAGS="" go ${action} "$1" || install_failed=1
-      popd > /dev/null 2>&1
-    else
-      GOFLAGS="" go ${action} "$1" || install_failed=1
-    fi
+  local run=$1
+
+  if [[ "$(basename $1)" != "$2" ]]; then
+    echo "Assuming tool is in package $2"
+    run="${run}/$2"
   fi
-  (( install_failed )) && return ${install_failed}
-  shift 2
-  ${tool} "$@"
+
+  if [[ -z "$(go list -f '{{.Module.Version}}' $1)" ]]; then
+    echo "Tool $1/$2 is not included in hack/tools.go, falling back to non-hermetic install (via GOPATH)."
+    if [[ -z "$(which ${tool})" ]]; then
+      local action=get
+      [[ $1 =~ ^[\./].* ]] && action=install
+      # Avoid running `go get` from root dir of the repository, as it can change go.sum and go.mod files.
+      # See discussions in https://github.com/golang/go/issues/27643.
+      if [[ ${action} == "get" && $(pwd) == "${REPO_ROOT_DIR}" ]]; then
+        local temp_dir="$(mktemp -d)"
+        # Swallow the output as we are returning the stdout in the end.
+        pushd "${temp_dir}" > /dev/null 2>&1
+        GOFLAGS="" go ${action} "$1" || install_failed=1
+        popd > /dev/null 2>&1
+      else
+        GOFLAGS="" go ${action} "$1" || install_failed=1
+      fi
+    fi
+    (( install_failed )) && return ${install_failed}
+    shift 2
+    ${tool} "$@"
+  else
+    shift 2
+    GOFLAGS="-mod=vendor" go run "${run}" "$@"
+  fi
 }
 
 # Add function call to trap


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind <kind>

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->
Allows tools to be pulled in via go modules, which allows us to ensure the version of the tool used by various devs against the same commit matches exactly. When the tool is not found in a module, it will automatically fall back to the old logic.

The only instance where this will fail is if the module includes a different version of the tool than that installed in GOPATH.

Warns when non-hermetic mode is used, as it can be very difficult to main consistency across individual devs machines without
it.


User-visible changes in this PR:
None
