### PR TITLE
Set GOBIN in codegen-library.sh

### DIFF
--- a/codegen-library.sh
+++ b/codegen-library.sh
@@ -26,6 +26,7 @@ else
 fi
 
 export GOPATH=$(go_mod_gopath_hack)
+export GOBIN=${GOPATH}/bin # Set GOBIN explicitly as deepcopy-gen is installed by go install.
 export MODULE_NAME=$(go_mod_module_name)
 export CODEGEN_PKG=${CODEGEN_PKG:-$(cd ${REPO_ROOT_DIR}; ls -d -1 ./vendor/k8s.io/code-generator 2>/dev/null || echo ../code-generator)}
 export KNATIVE_CODEGEN_PKG=${KNATIVE_CODEGEN_PKG:-$(cd ${REPO_ROOT_DIR}; ls -d -1 ./vendor/knative.dev/pkg 2>/dev/null || echo ../pkg)}


### PR DESCRIPTION
If `GOBIN` is set to some directory, `go install` installs the binary
into GOBIN*1. And then, `hack/update-codegen.sh` (e.g. in serving repo)
fails due to missing `deepcopy-gen` binary installed by `go install` like:

```
--- Deepcopy Gen
hack/update-codegen.sh: line 84: /tmp/tmp.ZAaVX3NvIx/bin/deepcopy-gen: No such file or directory
```

Hence this PR sets `GOBIN` explicitly.

*1 https://golang.org/cmd/go/#hdr-Compile_and_install_packages_and_dependencies
> Executables are installed in the directory named by the GOBIN environment variable, which defaults to $GOPATH/bin or $HOME/go/bin if the GOPATH environment variable is not set.

**Release Note**

```release-note
NONE
```

/cc @n3wscott 

