### PR TITLE
Allow for ignoring arbitrary files with shellcheck

### DIFF
--- a/library.sh
+++ b/library.sh
@@ -773,9 +773,14 @@ function get_latest_knative_yaml_source() {
 function shellcheck_new_files() {
   declare -a array_of_files
   local failed=0
+
+  if [ -z "$SHELLCHECK_IGNORE_FILES" ]; then
+    SHELLCHECK_IGNORE_FILES="^vendor/"
+  fi
+
   readarray -t array_of_files < <(list_changed_files)
   for filename in "${array_of_files[@]}"; do
-    if echo "${filename}" | grep -q "^vendor/"; then
+    if echo "${filename}" | grep -q "$SHELLCHECK_IGNORE_FILES"; then
       continue
     fi
     if file "${filename}" | grep -q "shell script"; then


### PR DESCRIPTION
- We currently hardcode that the vendor/ directory should be ignored by shellcheck, but users leveraging our test-infra should be able to customize which files should be ignored.
