### PR TITLE
Don't redirect STDERR to /dev/null when querying pods

### DIFF
--- a/library.sh
+++ b/library.sh
@@ -163,7 +163,7 @@ function wait_until_pods_running() {
   for i in {1..150}; do  # timeout after 5 minutes
     # List all pods. Ignore Terminating pods as those have either been replaced through
     # a deployment or terminated on purpose (through chaosduck for example).
-    local pods="$(kubectl get pods --no-headers -n $1 2>/dev/null | grep -v Terminating)"
+    local pods="$(kubectl get pods --no-headers -n $1 | grep -v Terminating)"
     # All pods must be running (ignore ImagePull error to allow the pod to retry)
     local not_running_pods=$(echo "${pods}" | grep -v Running | grep -v Completed | grep -v ErrImagePull | grep -v ImagePullBackOff)
     if [[ -n "${pods}" ]] && [[ -z "${not_running_pods}" ]]; then


### PR DESCRIPTION
This function checks the status of pods in a namespace. It redirects STDERR to /dev/null, which makes failures hard to debug. This redirection is unnecessary as STDERR gets logged to console when using command substitution anyways. Not redirecting it would make failures easier to debug.