### PR TITLE
Update OWNERS_ALIASES to match autogen in community

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,7 +1,7 @@
 approvers:
   - technical-oversight-committee
-  - productivity-approvers
+  - productivity-writers
 
 reviewers:
-  - productivity-approvers
+  - productivity-writers
   - productivity-reviewers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -4,13 +4,12 @@ aliases:
     - grantr
     - markusthoemmes
     - mattmoor
-    - tcnghia
-  productivity-approvers:
-    - chaodaiG
+    - rhuss
+  productivity-writers:
     - chizhg
-    - coryrc
     - n3wscott
   productivity-reviewers:
-    - steuhs
-    - peterfeifanchen
-    - efiturri
+  - coryrc
+  - evankanderson
+  - steuhs
+  - yt3liu


### PR DESCRIPTION
See https://github.com/knative/community/pull/552 for the addition of groups/full OWNERS_ALIASES that will be synced.

This is a preparatory PR for landing OWNERS_ALIASES automation across the Knative org (alternative to the CODEOWNERS changes in knative-sandbox).

If this seems to be expanding permissions or otherwise likely to cause a problem, `/hold` this PR and comment here or on https://github.com/knative/community/pull/552.
