### PR TITLE
Fix default codegen pkg dir

### DIFF
--- a/codegen-library.sh
+++ b/codegen-library.sh
@@ -29,7 +29,7 @@ export GOPATH=$(go_mod_gopath_hack)
 export GOBIN=${GOPATH}/bin # Set GOBIN explicitly as deepcopy-gen is installed by go install.
 export MODULE_NAME=$(go_mod_module_name)
 export CODEGEN_PKG=${CODEGEN_PKG:-$(cd ${REPO_ROOT_DIR}; ls -d -1 ./vendor/k8s.io/code-generator 2>/dev/null || echo ../code-generator)}
-export KNATIVE_CODEGEN_PKG=${KNATIVE_CODEGEN_PKG:-$(cd ${REPO_ROOT_DIR}; ls -d -1 ./vendor/knative.dev/pkg 2>/dev/null || echo ../pkg)}
+export KNATIVE_CODEGEN_PKG=${KNATIVE_CODEGEN_PKG:-$(cd ${REPO_ROOT_DIR}; ls -d -1 ./vendor/knative.dev/pkg 2>/dev/null || echo "${REPO_ROOT_DIR}")}
 
 chmod +x ${CODEGEN_PKG}/generate-groups.sh
 chmod +x ${KNATIVE_CODEGEN_PKG}/hack/generate-knative.sh


### PR DESCRIPTION
When running in CI the directory isn't always called 'pkg'

<!-- Thanks for sending a pull request! -->

# Changes
- :bug: Don't assume the pkg dir is named `pkg` in the codegen lib script

/kind bug

We just started using this script in knative/pkg and it looks like it doesn't work in this edge-case scenario where pkg is the repo being updated, but it's checked out as `/home/runner/work/knobots/knobots` on Github Actions.

https://github.com/knative-sandbox/knobots/runs/2448216473?check_suite_focus=true

/assign @n3wscott @dprotaso 