### PR TITLE
Skip GOPATH hacks if the repository is already on GOPATH

### DIFF
--- a/codegen-library.sh
+++ b/codegen-library.sh
@@ -25,9 +25,9 @@ else
   exit
 fi
 
-export GOPATH=$(go_mod_gopath_hack)
-export GOBIN=${GOPATH}/bin # Set GOBIN explicitly as deepcopy-gen is installed by go install.
 export MODULE_NAME=$(go_mod_module_name)
+export GOPATH=$(go_mod_gopath_hack)
+export GOBIN="$(mktemp -d)" # Set GOBIN explicitly as deepcopy-gen is installed by go install.
 export CODEGEN_PKG=${CODEGEN_PKG:-$(cd ${REPO_ROOT_DIR}; ls -d -1 ./vendor/k8s.io/code-generator 2>/dev/null || echo ../code-generator)}
 export KNATIVE_CODEGEN_PKG=${KNATIVE_CODEGEN_PKG:-$(cd ${REPO_ROOT_DIR}; ls -d -1 ./vendor/knative.dev/pkg 2>/dev/null || echo "${REPO_ROOT_DIR}")}
 

--- a/library.sh
+++ b/library.sh
@@ -611,6 +611,12 @@ function go_mod_module_name() {
 # Intended to be used like:
 #   export GOPATH=$(go_mod_gopath_hack)
 function go_mod_gopath_hack() {
+    # Skip this if the directory is already checked out onto the GOPATH.
+  if [[ "${REPO_ROOT_DIR##$(go env GOPATH)}" != "$REPO_ROOT_DIR" ]]; then
+    go env GOPATH
+    return
+  fi
+
   local TMP_DIR="$(mktemp -d)"
   local TMP_REPO_PATH="${TMP_DIR}/src/$(go_mod_module_name)"
   mkdir -p "$(dirname "${TMP_REPO_PATH}")" && ln -s "${REPO_ROOT_DIR}" "${TMP_REPO_PATH}"


### PR DESCRIPTION
# Changes

As per title, this supports the case where the repositories are still checked out onto a working `$GOPATH`.

1. Moves the module check above the GOPATH hackery. This took ages to fetch if running in a `$GOPATH` scenario, for whatever reason.
2. Make the GOPATH hackery skip itself if the repository is already checked out onto a legit `$GOPATH`. It's not necessary then.
3. Create a random directory for `$GOBIN` to not pollute the local bin directory even if running on a legit `$GOPATH`.

/assign @n3wscott @slinkydeveloper 