### PR TITLE
Rollback random GOBIN and make it relative to GOPATH again

### DIFF
--- a/codegen-library.sh
+++ b/codegen-library.sh
@@ -27,7 +27,7 @@ fi
 
 export MODULE_NAME=$(go_mod_module_name)
 export GOPATH=$(go_mod_gopath_hack)
-export GOBIN="$(mktemp -d)" # Set GOBIN explicitly as deepcopy-gen is installed by go install.
+export GOBIN=${GOPATH}/bin # Set GOBIN explicitly as deepcopy-gen is installed by go install.
 export CODEGEN_PKG=${CODEGEN_PKG:-$(cd ${REPO_ROOT_DIR}; ls -d -1 ./vendor/k8s.io/code-generator 2>/dev/null || echo ../code-generator)}
 export KNATIVE_CODEGEN_PKG=${KNATIVE_CODEGEN_PKG:-$(cd ${REPO_ROOT_DIR}; ls -d -1 ./vendor/knative.dev/pkg 2>/dev/null || echo "${REPO_ROOT_DIR}")}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

This should fix the current breakage in our nightly update scripts. Tested this in an empty docker container (as opposed to my system) to make sure it actually works.