### PR TITLE
go-licenses fixed file permissions so we no longer need our workaround

### DIFF
--- a/library.sh
+++ b/library.sh
@@ -643,10 +643,6 @@ function update_licenses() {
   shift
   run_go_tool github.com/google/go-licenses go-licenses save "${dir}" --save_path="${dst}" --force || \
     { echo "--- FAIL: go-licenses failed to update licenses"; return 1; }
-  # Hack to make sure directories retain write permissions after save. This
-  # can happen if the directory being copied is a Go module.
-  # See https://github.com/google/go-licenses/issues/11
-  chmod -R +w "${dst}"
 }
 
 # Run go-licenses to check for forbidden licenses.


### PR DESCRIPTION
Fixed here: https://github.com/google/go-licenses/pull/65