### PR TITLE
Stop performing pre-releases

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -600,7 +600,6 @@ function publish_to_github() {
   [[ -n "${RELEASE_BRANCH}" ]] && commitish="--commitish=${RELEASE_BRANCH}"
   for i in {2..0}; do
     hub_tool release create \
-        --prerelease \
         ${attachments[@]} \
         --file="${description}" \
         "${commitish}" \


### PR DESCRIPTION
Fixes https://github.com/knative/client/issues/1404

If we decide we want to make this configurable on a per-repo basis, it's pretty easy to go back and mark existing releases as `prerelease`; see https://github.com/knative/client/issues/1404#issuecomment-893754761 for an example script.
