### PR TITLE
[#50] Add error message when Bash < 4

### DIFF
--- a/library.sh
+++ b/library.sh
@@ -18,6 +18,12 @@
 # to be used in test scripts and the like. It doesn't do anything when
 # called from command line.
 
+# Exit early with a message if Bash version is below 4
+if [ "${BASH_VERSINFO:-0}" -le 4 ]; then
+ echo "library.sh script needs Bash version >=4 to run"
+ exit 1
+fi
+
 # GCP project where all tests related resources live
 readonly KNATIVE_TESTS_PROJECT=knative-tests
 


### PR DESCRIPTION
On OSX, the default bash is 3.x and running update-codegen.sh fails with
  `library.sh: line 25: conditional binary operator expected`
because library.sh requires bash version > 4
Original issue - https://github.com/knative/hack/issues/50

# Changes
:gift: Add a fail early check with an actionable error message 

**Release Note**

```release-note
library.sh will exit with an error message if detected BASH version is < 4
```

