### PR TITLE
Allow to use `unset` Bash flag with presubmit-tests.sh script

### DIFF
--- a/presubmit-tests.sh
+++ b/presubmit-tests.sh
@@ -307,7 +307,7 @@ function main() {
     fi
   fi
 
-  [[ -z $1 ]] && set -- "--all-tests"
+  [[ -z ${1:-} ]] && set -- "--all-tests"
 
   local TESTS_TO_RUN=()
 


### PR DESCRIPTION
# Changes

- bug: Allow to use `unset` Bash flag with presubmit-tests.sh script

/kind bug

Fixes #81