### PR TITLE
Fix bash version check to allow v4 or later

### DIFF
--- a/library.sh
+++ b/library.sh
@@ -19,7 +19,7 @@
 # called from command line.
 
 # Exit early with a message if Bash version is below 4
-if [ "${BASH_VERSINFO:-0}" -le 4 ]; then
+if [ "${BASH_VERSINFO:-0}" -lt 4 ]; then
  echo "library.sh script needs Bash version >=4 to run"
  exit 1
 fi


### PR DESCRIPTION
The current bash version check uses `-le 4` so it does not allow bash v4.
bash v4 should be supported so the script should use `-lt 4` instead.

/cc @xtreme-sameer-vohra @chizhg 