### PR TITLE
Making `library.sh` aware of release-module

### DIFF
--- a/library.sh
+++ b/library.sh
@@ -557,7 +557,7 @@ function go_update_deps() {
 
   local UPGRADE=0
   local RELEASE="v9000.1" # release v9000 is so far in the future, it will always pick the default branch.
-  local RELEASE_MODULE="v9000.1"
+  local RELEASE_MODULE=""
   local DOMAIN="knative.dev"
   while [[ $# -ne 0 ]]; do
     parameter=$1


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

Add `--release-module` parameter to `go_update_deps()` so knobots can define the correct module version and not only the release branch. 