### PR TITLE
Release use `knative-vX.Y.Z` tag and infer go module tag version automatically

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -135,8 +135,7 @@ function master_version() {
 # For example, "v0.2.1" returns "2"
 # Parameters: $1 - release version label.
 function minor_version() {
-  local release="${1//v/}"
-  local tokens=(${release//\./ })
+  local tokens=(${1//\./ })
   echo "${tokens[1]}"
 }
 
@@ -631,6 +630,8 @@ function publish_to_github() {
   # v1.0.0 = v0.27.0
   # v1.0.1 = v0.27.1
   # v1.1.1 = v0.28.1
+  #
+  # See: https://github.com/knative/hack/pull/97
   if [[ "$TAG" == "v1"* ]]; then
     local release_minor=$(minor_version $TAG)
     local go_module_version="v0.$(( release_minor + 27 )).$(patch_version $TAG)"

--- a/release.sh
+++ b/release.sh
@@ -633,7 +633,7 @@ function publish_to_github() {
   # v1.1.1 = v0.28.1
   if [[ "$TAG" == "v1"* ]]; then
     local release_minor=$(minor_version $TAG)
-    local go_module_version="0.$(( release_minor + 27 )).$(patch_version $TAG)"
+    local go_module_version="v0.$(( release_minor + 27 )).$(patch_version $TAG)"
     git tag -a "${go_module_version}" -m "${title}"
     git_push tag "${go_module_version}"
   fi

--- a/test/unit/release-tests.sh
+++ b/test/unit/release-tests.sh
@@ -54,8 +54,8 @@ echo ">> Testing helper functions"
 
 test_function ${SUCCESS} "0.2" master_version "v0.2.1"
 test_function ${SUCCESS} "0.2" master_version "0.2.1"
-test_function ${SUCCESS} "1" release_build_number "v0.2.1"
-test_function ${SUCCESS} "1" release_build_number "0.2.1"
+test_function ${SUCCESS} "1" patch_version "v0.2.1"
+test_function ${SUCCESS} "1" patch_version "0.2.1"
 test_function ${SUCCESS} "deadbeef" hash_from_tag "v20010101-deadbeef"
 
 echo ">> Testing flag parsing"


### PR DESCRIPTION
Fixes: https://github.com/knative/hack/issues/97

This updates the release scripts to support two tag schemes:
- knative-vX.Y.Z
- vX.Y.Z

Note: when publishing to GitHub we look at the desired tag and if it matches `v1*` then we'll push the corresponding go module version tag.

The formula for the go module version is
- drop the major to 0
- add 27 to the minor
- patch version remains the same

See the document here: https://docs.google.com/document/d/1_khEw5_l8Zhh4FuY3NM56o_OM-cNWmmq1vXfLCxZqMA/edit?usp=sharing