### PR TITLE
:bug: Allows to see TAG from build_release func

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -82,10 +82,10 @@ function publish_to_gcs() {
 # These are global environment variables.
 SKIP_TESTS=0
 PRESUBMIT_TEST_FAIL_FAST=1
-TAG_RELEASE=0
+export TAG_RELEASE=0
 PUBLISH_RELEASE=0
 PUBLISH_TO_GITHUB=0
-TAG=""
+export TAG=""
 BUILD_COMMIT_HASH=""
 BUILD_YYYYMMDD=""
 BUILD_TIMESTAMP=""


### PR DESCRIPTION
# Changes

- :bug: Allows to see `TAG` and `TAG_RELEASE` from build_release func

/kind bug

Fixes https://github.com/knative-sandbox/kn-plugin-event/issues/77

## Justification

In https://github.com/knative-sandbox/kn-plugin-event/pull/90 we had implemented a way to properly tag binaries and images from values of `$TAG` (only when `TAG_RELEASE==1`). Unfortunately, those variables aren't exported, so the build process can't see them.

This change exports those two variables, so the release script will work properly for kn event plugin.