### PR TITLE
chore: further explain knative CRD-generation support

### DIFF
--- a/schema/README.md
+++ b/schema/README.md
@@ -2,7 +2,11 @@
 
 Schema is a seed of a CLI tool that a downstream can use to use reflection and go file inspection to 
 generate a base version of OpenAPI for a CRD. The resulting schema will be used by Kubernetes to
-provide results from `kubectl explain <type>` calls, and type validation.  
+provide results from `kubectl explain <type>` calls, and type validation.
+
+Knative does not currently support full CRD generation via tools like 
+[controller-gen][controller-gen], this tool is to be used to support managing CRD manifests 
+manually.
 
 ## Integration steps
 
@@ -36,3 +40,5 @@ Paste this inside the CRD for LoremIpsum,
 
 Start with [example.go](./example.go), copy this into the downstream and modify which 
 kinds are registered via `registry.Register`. You can register more than one kind at a time. (TODO: support versions in the CLI.)
+                
+[controller-gen]: https://github.com/kubernetes-sigs/controller-tools/tree/master/cmd/controller-gen


### PR DESCRIPTION
Many new contributors will have had experience with other k8s tooling like the Operator SDK and as
such may expect CRD generation to be a standard feature within the Knative tooling (myself being
an example). This change adds an extra explanation of Knative's position on CRD generation, and 
should make this tool more easily-discoverable via GitHub search by including keywords like
"CRD generation" and "controller-gen".

<!-- Thanks for sending a pull request! -->

# Changes

:broom: Update README.md

/kind documentation

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
This isn't assigned an issue, I needed to ask on Slack to find this repo so thought it would be worth clarifying for future new contributors.
