### PR TITLE
Fix run_go_tool to use GOPATH/bin (#132)

### DIFF
--- a/library.sh
+++ b/library.sh
@@ -567,7 +567,7 @@ function run_go_tool() {
   fi
   (( install_failed )) && return ${install_failed}
   shift 2
-  ${tool} "$@"
+  ${GOPATH}/bin/${tool} "$@"
 }
 
 # Add function call to trap


### PR DESCRIPTION
# Changes

Function run_go_tool at library.sh to run commands from GOPATH/bin

If is not set, the following error occurs:

```
🚒 Update
=== Update Deps for Golang
--- Go mod tidy and vendor
--- Removing unwanted vendor files
--- Updating licenses
go get: installing executables with 'go get' in module mode is deprecated.
        Use 'go install pkg@version' instead.
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.
/home/user/knative/kn-plugin-quickstart/hack/../vendor/knative.dev/hack/library.sh: line 570: go-licenses: command not found
--- FAIL: go-licenses failed to update licenses
```

/kind bug

Fixes #132

**Release Note**

```release-note
No impact
```

**Docs**

```docs
- [Go documentation]: https://pkg.go.dev/cmd/go#hdr-GOPATH_environment_variable
```
