### PR TITLE
:bug: No longer fail if teardown function isn't defined

### DIFF
--- a/e2e-tests.sh
+++ b/e2e-tests.sh
@@ -17,7 +17,7 @@
 # This is a helper script for Knative E2E test scripts.
 # See README.md for instructions on how to use it.
 
-source $(dirname "${BASH_SOURCE[0]}")/infra-library.sh
+source "$(dirname "${BASH_SOURCE[0]:-$0}")/infra-library.sh"
 
 readonly TEST_RESULT_FILE=/tmp/${REPO_NAME}-e2e-result
 
@@ -29,8 +29,12 @@ function teardown_test_resources() {
   # On boskos, save time and don't teardown as the cluster will be destroyed anyway.
   (( IS_BOSKOS )) && return
   header "Tearing down test environment"
-  function_exists test_teardown && test_teardown
-  function_exists knative_teardown && knative_teardown
+  if function_exists test_teardown; then
+    test_teardown
+  fi
+  if function_exists knative_teardown; then
+    knative_teardown
+  fi
 }
 
 # Run the given E2E tests. Assume tests are tagged e2e, unless `-tags=XXX` is passed.

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -23,7 +23,9 @@
 # Calling this script without arguments will create a new cluster in
 # project $PROJECT_ID, run the tests and delete the cluster.
 
-source $(dirname "${BASH_SOURCE[0]}")/../e2e-tests.sh
+set -Eeo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]:-$0}")/../e2e-tests.sh"
 
 function knative_setup() {
   start_latest_knative_serving
@@ -33,6 +35,8 @@ function knative_setup() {
 initialize "$@" --max-nodes=1 --machine=e2-standard-2 \
   --enable-workload-identity --cluster-version=latest \
   --extra-gcloud-flags "--enable-stackdriver-kubernetes --no-enable-ip-alias --no-enable-autoupgrade"
+
+set -Eeuo pipefail
 
 go_test_e2e ./test/e2e || fail_test
 

--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -21,9 +21,11 @@
 # Use the flags --build-tests, --unit-tests and --integration-tests
 # to run a specific set of tests.
 
+set -Eeuo pipefail
+
 export GO111MODULE=on
 
-source $(dirname "${BASH_SOURCE[0]}")/../presubmit-tests.sh
+source "$(dirname "${BASH_SOURCE[0]:-$0}")/../presubmit-tests.sh"
 
 # Run our custom build tests after the standard build tests.
 


### PR DESCRIPTION
# Changes

- :bug: No longer fail if teardown function isn't defined knative/hack#136

/kind bug

Fixes knative/hack#136