### PR TITLE
Cleanup unnecessary clusteradmin grants

### DIFF
--- a/e2e-tests.sh
+++ b/e2e-tests.sh
@@ -73,9 +73,6 @@ function setup_test_cluster() {
   is_protected_cluster "${k8s_cluster}" && \
     abort "kubeconfig context set to ${k8s_cluster}, which is forbidden"
 
-  # Acquire cluster admin role for the current user.
-  acquire_cluster_admin_role "${k8s_cluster}"
-
   # Setup KO_DOCKER_REPO if it is a GKE cluster. Incorporate an element of
   # randomness to ensure that each run properly publishes images. Don't
   # owerwrite KO_DOCKER_REPO if already set.

--- a/infra-library.sh
+++ b/infra-library.sh
@@ -77,20 +77,6 @@ function dump_cluster_state() {
   echo "***************************************"
 }
 
-# Sets the current user as cluster admin for the given cluster.
-# Parameters: $1 - cluster context name
-function acquire_cluster_admin_role() {
-  if [[ -z "$(kubectl get clusterrolebinding cluster-admin-binding 2> /dev/null)" ]]; then
-    if [[ "$1" =~ ^gke_.* ]]; then
-      kubectl create clusterrolebinding cluster-admin-binding \
-        --clusterrole=cluster-admin --user="$(gcloud config get-value core/account)"
-    else
-      kubectl create clusterrolebinding cluster-admin-binding \
-        --clusterrole=cluster-admin --user="prow"
-    fi
-  fi
-}
-
 # Create a test cluster and run the tests if provided.
 # Parameters: $1 - cluster provider name, e.g. gke
 #             $2 - custom flags supported by kntest


### PR DESCRIPTION
/kind cleanup

Granting cluster-admin manually is a limitation in GKE that Google has fixed since 1.12 and we are using gcloud service account keys instead of the Metadata Service

https://web.archive.org/web/20201026161748/https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control
https://github.com/istio/istio.io/pull/8442﻿
