### PR TITLE
Temporarily fix the unit tests for library.sh

### DIFF
--- a/test/library_test.go
+++ b/test/library_test.go
@@ -46,13 +46,13 @@ func TestFails(t *testing.T) {
 func TestFailsWithFatal(t *testing.T) {
 	// Simulate a zap.Fatal() call.
 	fmt.Println("fatal\tTestFailsWithFatal\tsimple_test.go:999\tFailed with logger.Fatal()")
-	signal(os.Interrupt)
+	signal(os.Kill)
 }
 
 func TestFailsWithPanic(t *testing.T) {
 	// Simulate a "panic" stack trace.
 	fmt.Println("panic: test timed out after 5m0s")
-	signal(os.Interrupt)
+	signal(os.Kill)
 }
 
 func TestFailsWithSigQuit(t *testing.T) {


### PR DESCRIPTION
The unit tests for `library.sh` are failing, and it happened after the image update in https://github.com/knative/test-infra/pull/3014.

From the symptom the reason seems to be that `os.Interrupt` signal cannot be caught, since changing it to `os.Kill` will fix the tests. I wasn't able to figure out the root cause for it, so temporarily make the change to unblock PRs.