### PR TITLE
:broom: Migrate to using the `go run` instead of `go install`

### DIFF
--- a/foo/output_test.go
+++ b/foo/output_test.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2022 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package foo
+
+import "testing"
+
+func TestOutput(t *testing.T) {
+	t.Log("This message should be visible in extended test reports (JSONL, ANSI, HTML)")
+}

--- a/foo/short_test.go
+++ b/foo/short_test.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2022 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package foo
+
+import "testing"
+
+func TestShort(t *testing.T) {
+	if !testing.Short() {
+		t.Error("Expecting to have short flag set for unit tests")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module knative.dev/hack
 
-go 1.14
+go 1.17

--- a/infra-library.sh
+++ b/infra-library.sh
@@ -17,7 +17,7 @@
 # This is a collection of functions for infra related setups, mainly
 # cluster provisioning. It doesn't do anything when called from command line.
 
-source $(dirname "${BASH_SOURCE[0]}")/library.sh
+source "$(dirname "${BASH_SOURCE[0]:-$0}")/library.sh"
 
 # Dumps the k8s api server metrics. Spins up a proxy, waits a little bit and
 # dumps the metrics to ${ARTIFACTS}/k8s.metrics.txt

--- a/library.sh
+++ b/library.sh
@@ -40,7 +40,7 @@ fi
 readonly IS_PROW
 [[ ! -v REPO_ROOT_DIR ]] && REPO_ROOT_DIR="$(git rev-parse --show-toplevel)"
 readonly REPO_ROOT_DIR
-readonly REPO_NAME="$(basename ${REPO_ROOT_DIR})"
+readonly REPO_NAME="${REPO_NAME:-$(basename "${REPO_ROOT_DIR}")}"
 
 # Useful flags about the current OS
 IS_LINUX=0
@@ -56,10 +56,15 @@ readonly IS_LINUX
 readonly IS_OSX
 readonly IS_WINDOWS
 
+export TMPDIR="${TMPDIR:-$(mktemp -u -t -d knative.XXXXXXXX)}"
+mkdir -p "$TMPDIR"
 # Set ARTIFACTS to an empty temp dir if unset
 if [[ -z "${ARTIFACTS:-}" ]]; then
-  export ARTIFACTS="$(mktemp -d)"
+  ARTIFACTS="$(mktemp -u -t -d)"
+  export ARTIFACTS
 fi
+mkdir -p "$ARTIFACTS"
+
 
 # On a Prow job, redirect stderr to stdout so it's synchronously added to log
 (( IS_PROW )) && exec 2>&1
@@ -429,7 +434,7 @@ function mktemp_with_extension() {
 function create_junit_xml() {
   local xml
   xml="$(mktemp_with_extension "${ARTIFACTS}"/junit_XXXXXXXX xml)"
-  echo "JUnit file ${xml} is created for reporting the test result"
+  echo "XML report for $1::$2 written to ${xml}"
   run_kntest junit --suite="$1" --name="$2" --err-msg="$3" --dest="${xml}" || return 1
 }
 
@@ -437,37 +442,38 @@ function create_junit_xml() {
 # Parameters: $1... - parameters to go test
 function report_go_test() {
   local go_test_args=( "$@" )
-  # Install gotestsum if necessary.
-  run_go_tool gotest.tools/gotestsum gotestsum --help > /dev/null 2>&1
-  # Capture the test output to the report file.
-  local report
-  report="$(mktemp)"
-  local xml
+  local logfile xml ansilog htmllog
   xml="$(mktemp_with_extension "${ARTIFACTS}"/junit_XXXXXXXX xml)"
+  # Keep the suffix, so files are related.
+  logfile="${xml/junit_/go_test_}"
+  logfile="${logfile/.xml/.jsonl}"
   echo "Running go test with args: ${go_test_args[*]}"
-  capture_output "${report}" gotestsum --format "${GO_TEST_VERBOSITY:-testname}" \
-    --junitfile "${xml}" --junitfile-testsuite-name relative --junitfile-testcase-classname relative \
+  go_run gotest.tools/gotestsum@v1.8.0 \
+    --format "${GO_TEST_VERBOSITY:-testname}" \
+    --junitfile "${xml}" \
+    --junitfile-testsuite-name relative \
+    --junitfile-testcase-classname relative \
+    --jsonfile "${logfile}" \
     -- "${go_test_args[@]}"
-  local failed=$?
-  echo "Finished run, return code is ${failed}"
+  local gotest_retcode=$?
+  echo "Finished run, return code is ${gotest_retcode}"
 
   echo "XML report written to ${xml}"
-  if [[ -n "$(grep '<testsuites></testsuites>' "${xml}")" ]]; then
-    # XML report is empty, something's wrong; use the output as failure reason
-    create_junit_xml _go_tests "GoTests" "$(cat "${report}")"
-  fi
-  # Capture and report any race condition errors
-  local race_errors
-  race_errors="$(sed -n '/^WARNING: DATA RACE$/,/^==================$/p' "${report}")"
-  create_junit_xml _go_tests "DataRaceAnalysis" "${race_errors}"
-  if (( ! IS_PROW )); then
-    # Keep the suffix, so files are related.
-    local logfile=${xml/junit_/go_test_}
-    logfile=${logfile/.xml/.log}
-    cp "${report}" "${logfile}"
-    echo "Test log written to ${logfile}"
-  fi
-  return ${failed}
+  echo "Test log (JSONL) written to ${logfile}"
+
+  ansilog="${logfile/.jsonl/-ansi.log}"
+  go_run github.com/haveyoudebuggedit/gotestfmt/v2/cmd/gotestfmt@v2.3.1 \
+    -input "${logfile}" \
+    -showteststatus \
+    -nofail > "$ansilog"
+  echo "Test log (ANSI) written to ${ansilog}"
+
+  htmllog="${logfile/.jsonl/.html}"
+  go_run github.com/buildkite/terminal-to-html/v3/cmd/terminal-to-html@v3.6.1 \
+    --preview < "$ansilog" > "$htmllog"
+  echo "Test log (HTML) written to ${htmllog}"
+
+  return ${gotest_retcode}
 }
 
 # Install Knative Serving in the current cluster.
@@ -543,24 +549,45 @@ function start_latest_eventing_sugar_controller() {
   start_knative_eventing_extension "${KNATIVE_EVENTING_SUGAR_CONTROLLER_RELEASE}" "knative-eventing"
 }
 
+# Run a go utility without installing it.
+# Parameters: $1 - tool package for go run.
+#             $2..$n - parameters passed to the tool.
+function go_run() {
+  local package
+  package="$1"
+  if [[ "$package" != *@* ]]; then
+    abort 'Package for "go_run" needs to have @version'
+  fi
+  if [[ "$package" == *@latest ]] && [[ "$package" != knative.dev* ]]; then
+    warning 'Using @latest version for external dependencies is unsafe. Use numbered version!'
+  fi
+  shift 1
+  GORUN_PATH="${GORUN_PATH:-$(go env GOPATH)}"
+  # Some CI environments may have non-writable GOPATH
+  if ! [ -w "${GORUN_PATH}" ]; then
+    GORUN_PATH="$(mktemp -t -d -u gopath.XXXXXXXX)"
+  fi
+  export GORUN_PATH
+  GOPATH="${GORUN_PATH}" \
+  GOFLAGS='' \
+  GO111MODULE='' \
+    go run "$package" "$@"
+}
+
 # Run a go tool, installing it first if necessary.
 # Parameters: $1 - tool package/dir for go install.
 #             $2 - tool to run.
 #             $3..$n - parameters passed to the tool.
+# Deprecated: use go_run instead
 function run_go_tool() {
+  warning 'The "run_go_tool" function is deprecated. Use "go_run" instead.'
   local package=$1
-  local tool=$2
-  local install_failed=0
   # If no `@version` is provided, default to adding `@latest`
   if [[ "$package" != *@* ]]; then
     package=$package@latest
   fi
-  if [[ -z "$(which ${tool})" ]]; then
-    GOFLAGS="" go install "$package" || install_failed=1
-  fi
-  (( install_failed )) && return ${install_failed}
   shift 2
-  ${tool} "$@"
+  go_run "$package" "$@"
 }
 
 # Add function call to trap
@@ -623,7 +650,7 @@ function go_update_deps() {
     else
       group "Upgrading to release ${RELEASE}"
     fi
-    FLOATING_DEPS+=( $(run_go_tool knative.dev/test-infra/buoy buoy float ${REPO_ROOT_DIR}/go.mod "${buoyArgs[@]}") )
+    FLOATING_DEPS+=( $(go_run knative.dev/test-infra/buoy@latest buoy float ${REPO_ROOT_DIR}/go.mod "${buoyArgs[@]}") )
     if [[ ${#FLOATING_DEPS[@]} > 0 ]]; then
       echo "Floating deps to ${FLOATING_DEPS[@]}"
       go get -d ${FLOATING_DEPS[@]}
@@ -684,13 +711,10 @@ function go_mod_gopath_hack() {
   echo "${TMP_DIR}"
 }
 
-# Run kntest tool, error out and ask users to install it if it's not currently installed.
+# Run kntest tool
 # Parameters: $1..$n - parameters passed to the tool.
 function run_kntest() {
-  if [[ ! -x "$(command -v kntest)" ]]; then
-    echo "--- FAIL: kntest not installed, please clone knative test-infra repo and run \`go install ./tools/kntest/cmd/kntest\` to install it"; return 1;
-  fi
-  kntest "$@"
+  go_run knative.dev/test-infra/tools/kntest/cmd/kntest@latest "$@"
 }
 
 # Run go-licenses to update licenses.
@@ -701,14 +725,16 @@ function update_licenses() {
   local dst=$1
   local dir=$2
   shift
-  run_go_tool github.com/google/go-licenses go-licenses save "${dir}" --save_path="${dst}" --force || \
+  go_run github.com/google/go-licenses@v1.2.0 \
+    save "${dir}" --save_path="${dst}" --force || \
     { echo "--- FAIL: go-licenses failed to update licenses"; return 1; }
 }
 
 # Run go-licenses to check for forbidden licenses.
 function check_licenses() {
   # Check that we don't have any forbidden licenses.
-  run_go_tool github.com/google/go-licenses go-licenses check "${REPO_ROOT_DIR}/..." || \
+  go_run github.com/google/go-licenses@v1.2.0 \
+    check "${REPO_ROOT_DIR}/..." || \
     { echo "--- FAIL: go-licenses failed the license check"; return 1; }
 }
 

--- a/presubmit-tests.sh
+++ b/presubmit-tests.sh
@@ -185,7 +185,7 @@ function run_unit_tests() {
 
 # Default unit test runner that runs all go tests in the repo.
 function default_unit_test_runner() {
-  report_go_test -race -count 1 ./...
+  report_go_test -short -race -count 1 ./...
 }
 
 # Run integration tests. If there's no `integration_tests` function, run the

--- a/release.sh
+++ b/release.sh
@@ -18,7 +18,6 @@
 # See README.md for instructions on how to use it.
 
 source $(dirname "${BASH_SOURCE[0]}")/library.sh
-set -x
 
 # Organization name in GitHub; defaults to Knative.
 readonly ORG_NAME="${ORG_NAME:-knative}"
@@ -108,7 +107,7 @@ export GITHUB_TOKEN=""
 # Convenience function to run the hub tool.
 # Parameters: $1..$n - arguments to hub.
 function hub_tool() {
-  run_go_tool github.com/github/hub hub $@
+  gorun github.com/github/hub@v2.14.2 "$@"
 }
 
 # Shortcut to "git push" that handles authentication.

--- a/test/e2e-kind.sh
+++ b/test/e2e-kind.sh
@@ -14,7 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-source $(dirname "${BASH_SOURCE[0]}")/../e2e-tests.sh
+set -Eeo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]:-$0}")/../e2e-tests.sh"
 
 function knative_setup() {
   start_latest_knative_serving

--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -24,6 +24,7 @@
 set -Eeuo pipefail
 
 export GO111MODULE=on
+export REPO_NAME=hack
 
 source "$(dirname "${BASH_SOURCE[0]:-$0}")/../presubmit-tests.sh"
 
@@ -44,9 +45,11 @@ function post_unit_tests() {
   local failed=0
   for test in ./test/unit/*-tests.sh; do
     subheader "Running tests in ${test}"
-    ${test} || { failed=1; echo "--- FAIL: ${test}"; }
+    ${test} || { failed=$?; echo "--- FAIL: ${test}"; }
+    if (( failed )); then
+      return ${failed}
+    fi
   done
-  return ${failed}
 }
 
 # We use the default integration test runner.

--- a/test/unit/test-helper.sh
+++ b/test/unit/test-helper.sh
@@ -26,11 +26,12 @@ readonly FAILURE=1
 function test_function() {
   local expected_retcode=$1
   local expected_string=$2
-  local output="$(mktemp)"
-  local output_code="$(mktemp)"
+  local output output_code retcode
+  output="$(mktemp)"
+  output_code="$(mktemp)"
   shift 2
-  echo -n "$(trap '{ echo $? > ${output_code}; }' EXIT ; "$@")" &> ${output}
-  local retcode=$(cat ${output_code})
+  echo -n "$(trap '{ echo $? > ${output_code}; }' EXIT ; "$@")" &> "${output}"
+  retcode=$(cat "${output_code}")
   if [[ ${retcode} -ne ${expected_retcode} ]]; then
     cat ${output}
     echo "Return code ${retcode} doesn't match expected return code ${expected_retcode}"


### PR DESCRIPTION
# Changes

- :broom: Migrate to using the `go run` instead of `go install`
- :gift: Collecting JSONL, ANSI and nice HTML logs from all go tests
- :wastebasket: Removal of redundant manual race detection processing, and empty test suites handlers

/kind cleanup

Fixes #170 

