### PR TITLE
Skip passing enable-ha flag to test script

### DIFF
--- a/e2e-tests.sh
+++ b/e2e-tests.sh
@@ -152,7 +152,12 @@ function initialize() {
         # Skip parsed flag (and possibly argument) and continue
         # Also save it to it's passed through to the test script
         for ((i=1;i<=skip;i++)); do
-          e2e_script_command+=("$1")
+          case "$1" in
+            # Don't need to pass enable-ha to the test script
+            # For details, see https://github.com/knative/serving/issues/12788
+            --enable-ha) : ;;
+            *) e2e_script_command+=("$1") ;;
+          esac
           shift
         done
         continue

--- a/e2e-tests.sh
+++ b/e2e-tests.sh
@@ -137,13 +137,17 @@ CLOUD_PROVIDER="gke"
 function initialize() {
   local run_tests=0
   local custom_flags=()
+  local parse_script_flags=0
   E2E_SCRIPT="$(get_canonical_path "$0")"
   local e2e_script_command=( "${E2E_SCRIPT}" "--run-tests" )
+
+  for i in "$@"; do
+    if [[ $i == "--run-tests" ]]; then parse_script_flags=1; fi
+  done
 
   cd "${REPO_ROOT_DIR}"
   while [[ $# -ne 0 ]]; do
     local parameter=$1
-    # TODO(chizhg): remove parse_flags logic if no repos are using it.
     # Try parsing flag as a custom one.
     if function_exists parse_flags; then
       parse_flags "$@"
@@ -152,12 +156,10 @@ function initialize() {
         # Skip parsed flag (and possibly argument) and continue
         # Also save it to it's passed through to the test script
         for ((i=1;i<=skip;i++)); do
-          case "$1" in
-            # Don't need to pass enable-ha to the test script
-            # For details, see https://github.com/knative/serving/issues/12788
-            --enable-ha) : ;;
-            *) e2e_script_command+=("$1") ;;
-          esac
+          # Avoid double-parsing 
+          if (( parse_script_flags )); then
+            e2e_script_command+=("$1")
+          fi
           shift
         done
         continue


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paulschw@us.ibm.com>

Serving uses the `--enable-ha` flag in several of its e2e tests, but
parsing it out causes the flag to end up getting passed twice (once as
part of the script, and once from the parse out). So this PR fixes that
problem by not passing it as part of the e2e script commands.

For more details, see https://github.com/knative/serving/issues/12788

Fixes https://github.com/knative/serving/issues/12788

/assign @dprotaso 