### PR TITLE
Model []byte as strings

### DIFF
--- a/schema/example/schema.go
+++ b/schema/example/schema.go
@@ -56,6 +56,9 @@ type LoremIpsumSpec struct {
 	// Bbb is the second way.
 	Bbb LoremSpec `json:"bbb,omitempty"`
 
+	// Ccc is the third way.
+	Ccc []byte `json:"ccc,omitempty"`
+
 	// VerboseTypes shows an example of a ton of types.
 	VerboseTypes VerboseTypes `json:"verboseTypes"`
 }

--- a/schema/example_test.go
+++ b/schema/example_test.go
@@ -73,6 +73,9 @@ func Example_kindLoremIpsum() {
 	//           praesent:
 	//             description: Praesent pulvinar consectetur enim. Aenean lobortis, eros quis molestie euismod, nisl nunc mattis quam, et gravida risus diam at nulla. Donec interdum, tortor a semper tincidunt, nibh odio euismod orci, rhoncus rhoncus purus lacus pharetra mi. Suspendisse placerat dignissim magna convallis dictum. Nulla facilisi. Vivamus sed tristique turpis.
 	//             type: string
+	//       ccc:
+	//         description: Ccc is the third way.
+	//         type: string
 	//       maecenas:
 	//         description: Maecenas tristique lobortis turpis, nec varius mauris vestibulum nec. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Vivamus non dapibus magna.
 	//         type: string

--- a/schema/schema/generate_schema.go
+++ b/schema/schema/generate_schema.go
@@ -126,6 +126,12 @@ func generateSchema(t reflect.Type, history ...reflect.Type) JSONSchemaProps {
 	case reflect.Ptr:
 		return generateSchema(t.Elem(), history...)
 	case reflect.Slice:
+		// Model []byte as string
+		if t.Elem().Kind() == reflect.Uint8 {
+			return JSONSchemaProps{
+				Type: "string",
+			}
+		}
 		s := generateSliceSchema(t)
 		return s
 	case reflect.String:

--- a/schema/schema/generate_schema.go
+++ b/schema/schema/generate_schema.go
@@ -126,7 +126,10 @@ func generateSchema(t reflect.Type, history ...reflect.Type) JSONSchemaProps {
 	case reflect.Ptr:
 		return generateSchema(t.Elem(), history...)
 	case reflect.Slice:
-		// Model []byte as string
+		// From: https://pkg.go.dev/encoding/json#Marshal
+		// Array and slice values encode as JSON arrays, except that []byte
+		// encodes as a base64-encoded string, and a nil slice encodes as the
+		// null JSON value.
 		if t.Elem().Kind() == reflect.Uint8 {
 			return JSONSchemaProps{
 				Type: "string",


### PR DESCRIPTION
- :bug: Fix bug
/kind bug

Today a `[]byte` field gets the schema `array` of integers between `0` and `255`.

If you look at `Secret` in k8s:
```
kubectl explain secret.data
KIND:     Secret
VERSION:  v1

FIELD:    data <map[string]string>

DESCRIPTION:
     Data contains the secret data. Each key must consist of alphanumeric
     characters, '-', '_' or '.'. The serialized form of the secret data is a
     base64 encoded string, representing the arbitrary (possibly non-string)
     data value here. Described in https://tools.ietf.org/html/rfc4648#section-4
```

Where the Go type is `map[string][]byte`.

cc @dprotaso @evankanderson @vaikas 

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
