### PR TITLE
Set Go version by update-deps.sh

### DIFF
--- a/library.sh
+++ b/library.sh
@@ -61,6 +61,8 @@ if [[ -z "${ARTIFACTS:-}" ]]; then
   export ARTIFACTS="$(mktemp -d)"
 fi
 
+export GOVERSION="${GOVERSION:-1.17}"
+
 # On a Prow job, redirect stderr to stdout so it's synchronously added to log
 (( IS_PROW )) && exec 2>&1
 
@@ -631,6 +633,9 @@ function go_update_deps() {
       echo "Nothing to upgrade."
     fi
   fi
+
+  group "Set Go version"
+  go mod edit -go=${GOVERSION}
 
   group "Go mod tidy and vendor"
 


### PR DESCRIPTION
Currently Go version is not consistent and every repository needs to bump the go version in `go.mod` manually like these commits:

https://github.com/knative-sandbox/net-kourier/commit/53f2bec99c447c4d5d332a89f894664befb3c128
https://github.com/knative-sandbox/net-certmanager/commit/8f622b7cbfb1829edb4863ce89930f0cf9673a1c

This patch sets the go version in go.mod automatically by `update-deps.sh`.