### PR TITLE
remove references to markdown checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,29 +12,14 @@ This is a helper script to run the presubmit tests. To use it:
 1. [optional] Define the function `build_tests()`. If you don't define this
    function, the default action for running the build tests is to:
 
-   - check markdown files
    - run `go build` on the entire repo
    - run `/hack/verify-codegen.sh` (if it exists)
    - check licenses in all go packages
-
-   The markdown link checker tool doesn't check `localhost` links by default.
-   Its configuration file, `markdown-link-check-config.json`, lives in the
-   `hack` directory. To override it, create a file with the same name,
-   containing the custom config in the `/test` directory.
-
-   The markdown lint tool ignores long lines by default. Its configuration file,
-   `markdown-lint-config.rc`, lives in the `hack` repo. To override it, create a
-   file with the same name, containing the custom config in the `/test`
-   directory.
 
 1. [optional] Customize the default build test runner, if you're using it. Set
    the following environment variables if the default values don't fit your
    needs:
 
-   - `DISABLE_MD_LINTING`: Disable linting markdown files, defaults to 0
-     (false).
-   - `DISABLE_MD_LINK_CHECK`: Disable checking links in markdown files, defaults
-     to 0 (false).
    - `PRESUBMIT_TEST_FAIL_FAST`: Fail the presubmit test immediately if a test
      fails, defaults to 0 (false).
 

--- a/test/unit/presubmit-tests.sh
+++ b/test/unit/presubmit-tests.sh
@@ -33,15 +33,7 @@ function init_test_env() {
     echo "foobar.go"
   }
 
-  function markdown-link-check() {
-    return 0
-  }
-
   function mdl() {
-    return 0
-  }
-
-  function check_links_in_markdown() {
     return 0
   }
 


### PR DESCRIPTION
# Changes

🧹 Addresses: https://github.com/knative/test-infra/issues/3383

Markdown linting and link checking is no longer performed in the `presubmit-tests.sh` script.

This PR updates the README to remove references to the now non-existent markdown checking. It also removes two seemingly unreferenced functions from the `presubmit-tests.sh` in the unit test folder for markdown link checking.
