### PR TITLE
Output certificate when signing binaries

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -328,11 +328,11 @@ function sign_release() {
   ## Check if there is checksums.txt file. If so, sign the checksum file
   if [[ -f "checksums.txt" ]]; then
       echo "Signing Images with the identity ${SIGNING_IDENTITY}"
-      COSIGN_EXPERIMENTAL=1 cosign sign-blob checksums.txt --output-signature checksums.txt.sig --identity-token="$(
+      COSIGN_EXPERIMENTAL=1 cosign sign-blob checksums.txt --output-signature=checksums.txt.sig --output-certificate=checksums.txt.pem --identity-token="$(
         gcloud auth print-identity-token --audiences=sigstore \
         --include-email \
         --impersonate-service-account="${SIGNING_IDENTITY}")"
-      ARTIFACTS_TO_PUBLISH="${ARTIFACTS_TO_PUBLISH} checksums.txt.sig"
+      ARTIFACTS_TO_PUBLISH="${ARTIFACTS_TO_PUBLISH} checksums.txt.sig checksums.txt.pem"
   fi
 }
 


### PR DESCRIPTION
/kind enhancement

cosign transparency log doesn't work properly without a certificate being supplied when verifying signatures.


```
 REDACTED  MCW0CDP3YY  tmp  client  latest  $  COSIGN_EXPERIMENTAL=1 cosign verify-blob --signature checksums.txt.sig checksums.txt
WARNING: No valid entries were found in rekor to verify this blob.

Transparency log support for blobs is experimental, and occasionally an entry isn't found even if one exists.

We recommend requesting the certificate/signature from the original signer of this blob and manually verifying with cosign verify-blob --cert [cert] --signature [signature].
Error: verifying blob [checksums.txt]: could not find a valid tlog entry for provided blob, found 1 invalid entries
main.go:62: error during command execution: verifying blob [checksums.txt]: could not find a valid tlog entry for provided blob, found 1 invalid entries
```

/cc @cardil 