### PR TITLE
Notarize Mac binaries

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -104,6 +104,9 @@ ARTIFACTS_TO_PUBLISH=""
 FROM_NIGHTLY_RELEASE=""
 FROM_NIGHTLY_RELEASE_GCS=""
 SIGNING_IDENTITY=""
+APPLE_CODESIGN_KEY=""
+APPLE_NOTARY_API_KEY=""
+APPLE_CODESIGN_PASSWORD_FILE=""
 export KO_DOCKER_REPO="gcr.io/knative-nightly"
 # Build stripped binary to reduce size
 export GOFLAGS="-ldflags=-s -ldflags=-w"
@@ -314,6 +317,21 @@ function sign_release() {
   if [ -z "${SIGN_IMAGES:-}" ]; then # Temporary Feature Gate
     return 0
   fi
+
+  # Notarizing mac binaries needs to be done before cosign as it changes the checksum values
+  # of the darwin binaries
+  if [ -n "${APPLE_CODESIGN_KEY}" && -n "${APPLE_CODESIGN_PASSWORD}" && -n "${APPLE_NOTARY_API_KEY}" ]; then
+    FILES=$(find * -type f -name "*darwin*")
+    for file in $FILES; do
+      rcodesign sign "${file}" --p12-file="${APPLE_CODESIGN_KEY}" \
+        --code-signature-flags=runtime \
+        --p12-password-file="${APPLE_CODESIGN_PASSWORD_FILE}"
+    done
+    zip files.zip $FILES
+    sha256sum ${ARTIFACTS_TO_PUBLISH} > checksums.txt
+    rcodesign notary-submit files.zip --api-key-path="${APPLE_NOTARY_API_KEY}"  --wait
+  fi
+
   ## Sign the images with cosign
   ## For now, check if ko has created imagerefs.txt file. In the future, missing image refs will break
   ## the release for all jobs that publish images.
@@ -437,6 +455,15 @@ function parse_flags() {
           --from-nightly)
             [[ $1 =~ ^v[0-9]+-[0-9a-f]+$ ]] || abort "nightly tag must be 'vYYYYMMDD-commithash'"
             FROM_NIGHTLY_RELEASE=$1
+            ;;
+          --apple-codesign-key)
+            APPLE_CODESIGN_KEY=$1
+            ;;
+          --apple-codesign-password-file)
+            APPLE_CODESIGN_PASSWORD_FILE=$1
+            ;;
+          --apple-notary-api-key)
+            APPLE_NOTARY_API_KEY=$1
             ;;
           *) abort "unknown option ${parameter}" ;;
         esac

--- a/release.sh
+++ b/release.sh
@@ -320,16 +320,16 @@ function sign_release() {
 
   # Notarizing mac binaries needs to be done before cosign as it changes the checksum values
   # of the darwin binaries
-  if [ -n "${APPLE_CODESIGN_KEY}" && -n "${APPLE_CODESIGN_PASSWORD}" && -n "${APPLE_NOTARY_API_KEY}" ]; then
-    FILES=$(find * -type f -name "*darwin*")
+ if [ -n "${APPLE_CODESIGN_KEY}" ] && [ -n "${APPLE_CODESIGN_PASSWORD}" ] && [ -n "${APPLE_NOTARY_API_KEY}" ]; then
+    FILES=$(find -- * -type f -name "*darwin*")
     for file in $FILES; do
       rcodesign sign "${file}" --p12-file="${APPLE_CODESIGN_KEY}" \
         --code-signature-flags=runtime \
         --p12-password-file="${APPLE_CODESIGN_PASSWORD_FILE}"
     done
-    zip files.zip $FILES
-    sha256sum ${ARTIFACTS_TO_PUBLISH} > checksums.txt
-    rcodesign notary-submit files.zip --api-key-path="${APPLE_NOTARY_API_KEY}"  --wait
+    zip files.zip "$FILES"
+    rcodesign notary-submit files.zip --api-key-path="${APPLE_NOTARY_API_KEY}" --wait
+    sha256sum "${ARTIFACTS_TO_PUBLISH//checksums.txt/}" > checksums.txt
   fi
 
   ## Sign the images with cosign


### PR DESCRIPTION
Part of https://github.com/knative/test-infra/issues/3536

# Changes
- Allows mac binaries (GOOS=darwin) to be notarized.
- I need to upload the credentials to Google Secret Manager, load it to K8s and modify release/nightlies to use it.

/cc @cardil @kvmware 