### PR TITLE
drop support for the istio add on flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,9 +149,6 @@ This is a helper script for Knative E2E test scripts. To use it:
 1. By default `knative_teardown()` and `test_teardown()` will be called after
    the tests finish, use `--skip-teardowns` if you don't want them to be called.
 
-1. By default Istio is installed on the cluster via Addon, use
-   `--skip-istio-addon` if you choose not to have it preinstalled.
-
 1. By default Google Kubernetes Engine telemetry to Cloud Logging and Monitoring is disabled.
    This can be enabled by setting `ENABLE_GKE_TELEMETRY` to `true`.
    

--- a/test/unit/presubmit_test.go
+++ b/test/unit/presubmit_test.go
@@ -53,7 +53,7 @@ func TestMainFunc(t *testing.T) {
 				"--enable-workload-identity --cluster-version=latest "+
 				"--extra-gcloud-flags --enable-stackdriver-kubernetes "+
 				"--no-enable-ip-alias --no-enable-autoupgrade "+
-				"--addons=Istio,NodeLocalDNS "+
+				"--addons=NodeLocalDNS "+
 				"--test-command=%s/test/e2e-tests.sh "+
 				"--run-tests --extra-gcloud-flags= --logging=NONE "+
 				"--monitoring=NONE", rootDir)),

--- a/test/unit/run_e2e_test.go
+++ b/test/unit/run_e2e_test.go
@@ -15,7 +15,6 @@ func TestRunE2eTests(t *testing.T) {
 		stdout: []check{
 			contains("SETTING UP TEST CLUSTER"),
 			contains("Cluster is gke_deadbeef_1.24"),
-			contains("kubectl wait job --for=condition=Complete --all -n istio-system --timeout=5m"),
 			contains("STARTING KNATIVE SERVING"),
 			contains("Waiting until all pods in namespace knative-serving are up"),
 			contains("E2E TESTS PASSED"),


### PR DESCRIPTION
This thing is so old and we don't use it so drop it.

In the past we would be install the Istio add-on available in GKE but we ended up installing it ourselves.