### PR TITLE
Trap calls are now executed in LIFO order

### DIFF
--- a/library.sh
+++ b/library.sh
@@ -647,7 +647,7 @@ function add_trap {
     local current_trap
     current_trap="$(trap -p "$trap_signal" | cut -d\' -f2)"
     local new_cmd="($cmd)"
-    [[ -n "${current_trap}" ]] && new_cmd="${current_trap};${new_cmd}"
+    [[ -n "${current_trap}" ]] && new_cmd="${new_cmd};${current_trap}"
     trap -- "${new_cmd}" "$trap_signal"
   done
 }


### PR DESCRIPTION
We tend to add traps at various points in our test scripts.
The assumption we have is the trap will be executed when
external resources are in a certain state.

ie.
1. Setup Cluster - trap delete_cluster
2. Setup Knative - trap teardown_knative
3. Setup Tests   - trap dump_test_failure

Prior traps are executed in FIFO order so the cluster
would be torn down before the test dump would occur.

In LIFO order the test dump would occur first, then the
teardown of knative and then finally the cluster.

/assign @cardil 
/assign @upodroid 