### PR TITLE
Calculate Image references properly

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -98,7 +98,7 @@ RELEASE_NOTES=""
 RELEASE_BRANCH=""
 RELEASE_GCS_BUCKET="knative-nightly/${REPO_NAME}"
 RELEASE_DIR=""
-KO_FLAGS="-P --platform=all --image-refs=imagerefs.txt"
+KO_FLAGS="-P --platform=all"
 VALIDATION_TESTS="./test/presubmit-tests.sh"
 ARTIFACTS_TO_PUBLISH=""
 FROM_NIGHTLY_RELEASE=""
@@ -312,8 +312,22 @@ function build_from_source() {
   sign_release || abort "error signing the release"
 }
 
+function get_images_in_yamls() {
+  rm -rf imagerefs.txt
+  echo "Assembling a list of image refences to sign"
+  for file in $@; do
+    [[ "${file##*.}" != "yaml" ]] && continue
+    echo "Inspecting ${file}"
+    for image in $(grep -oh "\S*@sha256\S*" "${file}"); do
+      echo $image >> imagerefs.txt
+    done
+  done
+  sort -uo imagerefs.txt imagerefs.txt # Remove duplicate entries
+}
+
 # Build a release from source.
 function sign_release() {
+  get_images_in_yamls "${ARTIFACTS_TO_PUBLISH}"
   if (( ! IS_PROW )); then # This function can't be run by devs on their laptops
     return 0
   fi

--- a/release.sh
+++ b/release.sh
@@ -318,7 +318,7 @@ function get_images_in_yamls() {
   for file in $@; do
     [[ "${file##*.}" != "yaml" ]] && continue
     echo "Inspecting ${file}"
-    for image in $(grep -oh "\S*@sha256\S*" "${file}"); do
+    for image in $(grep -oh "\S*${KO_DOCKER_REPO}\S*" "${file}"); do
       echo $image >> imagerefs.txt
     done
   done


### PR DESCRIPTION
Closes: https://github.com/knative/serving/pull/13408
Part of https://github.com/knative/test-infra/issues/3345

Some repos (eventing/serving and others) override the `ko` flags so this change calculates the image references directly from the yaml manifests that are uploaded.

/cc @dprotaso @kvmware 