### PR TITLE
e2e script tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,10 @@ This is a helper script for Knative E2E test scripts. To use it:
    when a test fails, and can dump extra information about the current state of
    the cluster (typically using `kubectl`).
 
+1. [optional] Write the `on_success` function. It will be called when a test succeeds
+
+1. [optional] Write the `on_failure` function. It will be called when a test fails
+
 1. [optional] Write the `parse_flags()` function. It will be called whenever an
    unrecognized flag is passed to the script, allowing you to define your own
    flags. The function must return 0 if the flag is unrecognized, or the number

--- a/e2e-tests.sh
+++ b/e2e-tests.sh
@@ -21,13 +21,8 @@ source "$(dirname "${BASH_SOURCE[0]:-$0}")/infra-library.sh"
 
 readonly TEST_RESULT_FILE=/tmp/${REPO_NAME}-e2e-result
 
-# Flag whether test is using a boskos GCP project
-IS_BOSKOS=0
-
 # Tear down the test resources.
 function teardown_test_resources() {
-  # On boskos, save time and don't teardown as the cluster will be destroyed anyway.
-  (( IS_BOSKOS )) && return
   header "Tearing down test environment"
   if function_exists test_teardown; then
     test_teardown
@@ -89,10 +84,9 @@ function setup_test_cluster() {
   kubectl config set-context "${k8s_cluster}" --namespace=default
 
   echo "- Cluster is ${k8s_cluster}"
-  echo "- Docker is ${KO_DOCKER_REPO}"
+  echo "- KO_DOCKER_REPO is ${KO_DOCKER_REPO}"
 
-  # Do not run teardowns if we explicitly want to skip them.
-  (( ! SKIP_TEARDOWNS )) && add_trap teardown_test_resources EXIT
+  (( TEARDOWN )) && add_trap teardown_test_resources EXIT
 
   # Handle failures ourselves, so we can dump useful info.
   set +o errexit
@@ -127,17 +121,19 @@ function fail_test() {
   abort "${message}"
 }
 
-SKIP_TEARDOWNS=0
-E2E_SCRIPT=""
-CLOUD_PROVIDER="gke"
+# Since create_test_cluster invokes the test script
+# recursively we don't want to override these on the second
+# invocation
+TEARDOWN=${TEARDOWN:-0}
+CLOUD_PROVIDER=${CLOUD_PROVIDER:-"gke"}
 
 # Parse flags and initialize the test cluster.
 function initialize() {
   local run_tests=0
   local custom_flags=()
   local parse_script_flags=0
-  E2E_SCRIPT="$(get_canonical_path "$0")"
-  local e2e_script_command=( "${E2E_SCRIPT}" "--run-tests" )
+  local e2e_script="$(get_canonical_path "$0")"
+  local e2e_script_command=( "${e2e_script}" "--run-tests" )
 
   for i in "$@"; do
     if [[ $i == "--run-tests" ]]; then parse_script_flags=1; fi
@@ -154,7 +150,7 @@ function initialize() {
         # Skip parsed flag (and possibly argument) and continue
         # Also save it to it's passed through to the test script
         for ((i=1;i<=skip;i++)); do
-          # Avoid double-parsing 
+          # Avoid double-parsing
           if (( parse_script_flags )); then
             e2e_script_command+=("$1")
           fi
@@ -166,9 +162,9 @@ function initialize() {
     # Try parsing flag as a standard one.
     case ${parameter} in
       --run-tests) run_tests=1 ;;
-      --skip-teardowns) SKIP_TEARDOWNS=1 ;;
-      --skip-istio-addon) echo "--skip-istio-addon is no longer supported"
-        ;; # This flag is a noop
+      --teardown) TEARDOWN=1 ;;
+      --skip-teardowns) echo "--skip-teardowns is no longer supported - opt in with --teardown" ;;
+      --skip-istio-addon) echo "--skip-istio-addon is no longer supported" ;;
       *)
         case ${parameter} in
           --cloud-provider) shift; CLOUD_PROVIDER="$1" ;;
@@ -178,14 +174,12 @@ function initialize() {
     shift
   done
 
-  (( IS_PROW )) && [[ -z "${GCP_PROJECT_ID:-}" ]] && IS_BOSKOS=1
-
   if [[ "${CLOUD_PROVIDER}" == "gke" ]]; then
       custom_flags+=("--addons=NodeLocalDNS")
   fi
 
-  readonly IS_BOSKOS
-  readonly SKIP_TEARDOWNS
+  readonly TEARDOWN
+  readonly CLOUD_PROVIDER
 
   if (( ! run_tests )); then
     create_test_cluster "${CLOUD_PROVIDER}" custom_flags e2e_script_command

--- a/e2e-tests.sh
+++ b/e2e-tests.sh
@@ -126,14 +126,15 @@ function fail_test() {
 # invocation
 TEARDOWN=${TEARDOWN:-0}
 CLOUD_PROVIDER=${CLOUD_PROVIDER:-"gke"}
+E2E_SCRIPT=""
 
 # Parse flags and initialize the test cluster.
 function initialize() {
   local run_tests=0
   local custom_flags=()
   local parse_script_flags=0
-  local e2e_script="$(get_canonical_path "$0")"
-  local e2e_script_command=( "${e2e_script}" "--run-tests" )
+  E2E_SCRIPT="$(get_canonical_path "$0")"
+  local e2e_script_command=( "${E2E_SCRIPT}" "--run-tests" )
 
   for i in "$@"; do
     if [[ $i == "--run-tests" ]]; then parse_script_flags=1; fi

--- a/e2e-tests.sh
+++ b/e2e-tests.sh
@@ -111,7 +111,7 @@ function success() {
   echo "**************************************"
   echo "***        E2E TESTS PASSED        ***"
   echo "**************************************"
-  dump_metrics
+  function_exists on_success && on_success
   exit 0
 }
 
@@ -122,7 +122,8 @@ function fail_test() {
   if [[ "X${message:-}X" == "XX" ]]; then
     message='test failed'
   fi
-  add_trap "dump_cluster_state;dump_metrics" EXIT
+  function_exists on_failure && on_failure
+  add_trap "dump_cluster_state" EXIT
   abort "${message}"
 }
 

--- a/test/unit/e2e_helpers_test.go
+++ b/test/unit/e2e_helpers_test.go
@@ -27,8 +27,6 @@ func TestE2eHelpers(t *testing.T) {
 		retcode: retcode(111),
 		stdout: []check{
 			contains(">> DUMPING THE CLUSTER STATE"),
-			contains(">> STARTING KUBE PROXY"),
-			contains(">> GRABBING K8S METRICS"),
 		},
 	}}
 	for _, tc := range tcs {


### PR DESCRIPTION
- Don't `dump_metrics` by default - provide `on_success` & `on_failure` hooks as an alternative
- make env teardown optional

/hold going to test downstream