### PR TITLE
Upload attestations and print cosign version

### DIFF
--- a/presubmit-tests.sh
+++ b/presubmit-tests.sh
@@ -289,6 +289,10 @@ function main() {
       echo ">> maven version"
       mvn --version
     fi
+    if command -v cosign > /dev/null; then
+      echo ">> cosign version"
+      cosign version
+    fi
     echo ">> prow-tests image version"
     [[ -f /commit_hash ]] && echo "Prow test image was built from $(cat /commit_hash) commit which is viewable at https://github.com/knative/test-infra/tree/$(cat /commit_hash) " || echo "unknown"
   fi

--- a/release.sh
+++ b/release.sh
@@ -359,6 +359,7 @@ function sign_release() {
       if  [ -n "${ATTEST_IMAGES:-}" ]; then # Temporary Feature Gate
         provenance-generator --clone-log=/logs/clone.json \
           --image-refs=imagerefs.txt --output=attestation.json
+        mkdir -p "${ARTIFACTS}"/attestation && cp attestation.json "${ARTIFACTS}"/attestation
         COSIGN_EXPERIMENTAL=1 cosign attest $(cat imagerefs.txt) --recursive --identity-token="${ID_TOKEN}" \
           --predicate=attestation.json --type=slsaprovenance
       fi

--- a/test/unit/sharedlib_test.go
+++ b/test/unit/sharedlib_test.go
@@ -286,6 +286,7 @@ func fakeProwJob() scriptlet {
 		mockBinary("java"),
 		mockBinary("mvn"),
 		mockBinary("ko"),
+		mockBinary("cosign"),
 	)
 }
 


### PR DESCRIPTION
This change uploads the attesttation payload so we can view it with the job it was built from and we can see more clearly the cosign version we used.

/cc @kvmware 