### PR TITLE
Cleanup: remove ioutil for new go version

### DIFF
--- a/shell/executor.go
+++ b/shell/executor.go
@@ -19,7 +19,6 @@ package shell
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -134,7 +133,7 @@ func defaultPrefixFunc(st StreamType, label string, cfg ExecutorConfig) string {
 }
 
 func withTempScript(contents string, fn func(bin string) error) error {
-	tmpfile, err := ioutil.TempFile("", "shellout-*.sh")
+	tmpfile, err := os.CreateTemp("", "shellout-*.sh")
 	if err != nil {
 		return err
 	}

--- a/shell/project_test.go
+++ b/shell/project_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package shell_test
 
 import (
-	"io/ioutil"
+	"os"
 	"path"
 	"testing"
 
@@ -29,7 +29,7 @@ func TestNewProjectLocation(t *testing.T) {
 	loc, err := shell.NewProjectLocation("..")
 	assert.NoError(err)
 	goModPath := path.Join(loc.RootPath(), "go.mod")
-	bytes, err := ioutil.ReadFile(goModPath)
+	bytes, err := os.ReadFile(goModPath)
 	assert.NoError(err)
 	assert.Contains(string(bytes), "module knative.dev/hack")
 }


### PR DESCRIPTION
Remove ioutil for new go version: https://go.dev/doc/go1.16#ioutil

/kind cleanup