### PR TITLE
:broom: Use extracted tools from knative.dev/toolbox

### DIFF
--- a/library.sh
+++ b/library.sh
@@ -657,7 +657,7 @@ function foreach_go_module() {
       echo "Command '${cmd}' failed in module $gomod_dir: $failed" >&2
       return $failed
     fi
-  done < <(go_run knative.dev/test-infra/tools/modscope@latest ls -p)
+  done < <(go_run knative.dev/toolbox/modscope@latest ls -p)
 }
 
 # Update go deps.
@@ -709,7 +709,7 @@ function __go_update_deps_for_module() {
     else
       group "Upgrading to release ${RELEASE}"
     fi
-    FLOATING_DEPS+=( $(go_run knative.dev/test-infra/buoy@latest float ./go.mod "${buoyArgs[@]}") )
+    FLOATING_DEPS+=( $(go_run knative.dev/toolbox/buoy@latest float ./go.mod "${buoyArgs[@]}") )
     if [[ ${#FLOATING_DEPS[@]} > 0 ]]; then
       echo "Floating deps to ${FLOATING_DEPS[@]}"
       go get -d ${FLOATING_DEPS[@]}
@@ -754,7 +754,7 @@ function __go_update_deps_for_module() {
 # Intended to be used like:
 #   export MODULE_NAME=$(go_mod_module_name)
 function go_mod_module_name() {
-  go_run knative.dev/test-infra/tools/modscope@latest current
+  go_run knative.dev/toolbox/modscope@latest current
 }
 
 # Return a GOPATH to a temp directory. Works around the out-of-GOPATH issues
@@ -778,7 +778,7 @@ function go_mod_gopath_hack() {
 # Run kntest tool
 # Parameters: $1..$n - parameters passed to the tool.
 function run_kntest() {
-  go_run knative.dev/test-infra/tools/kntest/cmd/kntest@latest "$@"
+  go_run knative.dev/toolbox/kntest/cmd/kntest@latest "$@"
 }
 
 # Run go-licenses to update licenses.

--- a/presubmit-tests.sh
+++ b/presubmit-tests.sh
@@ -139,7 +139,7 @@ function __build_test_runner_for_module() {
   # Don't merge these two lines, or return code will always be 0.
   # Get all build tags in go code (ignore /vendor, /hack and /third_party)
   local tags
-  tags="$(go run knative.dev/test-infra/tools/go-ls-tags@latest --joiner=,)"
+  tags="$(go run knative.dev/toolbox/go-ls-tags@latest --joiner=,)"
   local go_pkg_dirs
   go_pkg_dirs="$(go list -tags "${tags}" ./...)" || return $?
   if [[ -z "${go_pkg_dirs}" ]]; then

--- a/test/unit/presubmit_test.go
+++ b/test/unit/presubmit_test.go
@@ -27,7 +27,7 @@ func TestMainFunc(t *testing.T) {
 			contains("go test -vet=off -tags e2e,hack,library -exec echo ./..."),
 			contains("go test -vet=off -tags e2e,library -exec echo ./..."),
 			contains("go test -vet=off -tags  -exec echo ./..."),
-			contains("go run knative.dev/test-infra/tools/kntest/cmd/kntest@latest" +
+			contains("go run knative.dev/toolbox/kntest/cmd/kntest@latest" +
 				" junit --suite=_build_tests --name=Check_Licenses --err-msg= --dest="),
 			contains("BUILD TESTS PASSED"),
 		},
@@ -48,7 +48,7 @@ func TestMainFunc(t *testing.T) {
 		stdout: []check{
 			contains("RUNNING INTEGRATION TESTS"),
 			contains("Running integration test test/e2e-tests.sh"),
-			contains(fmt.Sprintf("go run knative.dev/test-infra/tools/kntest/cmd/kntest@latest"+
+			contains(fmt.Sprintf("go run knative.dev/toolbox/kntest/cmd/kntest@latest"+
 				" kubetest2 gke --max-nodes=1 --machine=e2-standard-2 "+
 				"--enable-workload-identity --cluster-version=latest "+
 				"--extra-gcloud-flags --enable-stackdriver-kubernetes "+

--- a/test/unit/sharedlib_test.go
+++ b/test/unit/sharedlib_test.go
@@ -261,8 +261,8 @@ func (a anyArgs) String() string {
 }
 
 func mockGo(responses ...response) scriptlet {
-	lstags := "knative.dev/test-infra/tools/go-ls-tags@latest"
-	modscope := "knative.dev/test-infra/tools/modscope@latest"
+	lstags := "knative.dev/toolbox/go-ls-tags@latest"
+	modscope := "knative.dev/toolbox/modscope@latest"
 	callOriginals := []args{
 		startsWith{"run " + lstags},
 		startsWith{"run " + modscope},

--- a/test/unit/update_deps_test.go
+++ b/test/unit/update_deps_test.go
@@ -32,13 +32,13 @@ func TestUpdateDeps(t *testing.T) {
 	}, {
 		name: "go_update_deps --upgrade",
 		stdout: []check{
-			contains("go run knative.dev/test-infra/buoy@latest float ./go.mod " +
+			contains("go run knative.dev/toolbox/buoy@latest float ./go.mod " +
 				"--release v9000.1 --domain knative.dev"),
 		},
 	}, {
 		name: "go_update_deps --upgrade --release 1.25 --module-release 0.28",
 		stdout: []check{
-			contains("go run knative.dev/test-infra/buoy@latest float ./go.mod " +
+			contains("go run knative.dev/toolbox/buoy@latest float ./go.mod " +
 				"--release 1.25 --domain knative.dev --module-release 0.28"),
 		},
 	}}


### PR DESCRIPTION
# Changes

- :broom: Use extracted tools from knative.dev/toolbox

/kind cleanup

Related https://github.com/knative/toolbox/pull/3
Related https://github.com/knative/community/issues/1291
