### PR TITLE
Install Istio for e2e tests

### DIFF
--- a/test/e2e-kind.sh
+++ b/test/e2e-kind.sh
@@ -18,7 +18,49 @@ set -Eeo pipefail
 
 source "$(dirname "${BASH_SOURCE[0]:-$0}")/../e2e-tests.sh"
 
+export INGRESS_CLASS=${INGRESS_CLASS:-istio.ingress.networking.knative.dev}
+
+function is_ingress_class() {
+  [[ "${INGRESS_CLASS}" == *"${1}"* ]]
+}
+
+# Copied from https://github.com/knative/client/blob/main/test/common.sh#L32
+function install_istio() {
+  if [[ -z "${ISTIO_VERSION:-}" ]]; then
+    readonly ISTIO_VERSION="latest"
+  fi
+
+  header "Installing Istio ${ISTIO_VERSION}"
+  local LATEST_NET_ISTIO_RELEASE_VERSION=$(curl -L --silent "https://api.github.com/repos/knative/net-istio/releases" | \
+    jq -r '[.[].tag_name] | sort_by( sub("knative-";"") | sub("v";"") | split(".") | map(tonumber) ) | reverse[0]')
+  # And checkout the setup script based on that release
+  local NET_ISTIO_DIR=$(mktemp -d)
+  (
+    cd $NET_ISTIO_DIR \
+      && git init \
+      && git remote add origin https://github.com/knative-sandbox/net-istio.git \
+      && git fetch --depth 1 origin $LATEST_NET_ISTIO_RELEASE_VERSION \
+      && git checkout FETCH_HEAD
+  )
+
+  if [[ -z "${ISTIO_PROFILE:-}" ]]; then
+    readonly ISTIO_PROFILE="istio-ci-no-mesh.yaml"
+  fi
+
+  if [[ -n "${CLUSTER_DOMAIN:-}" ]]; then
+    sed -ie "s/cluster\.local/${CLUSTER_DOMAIN}/g" ${NET_ISTIO_DIR}/third_party/istio-${ISTIO_VERSION}/${ISTIO_PROFILE}
+  fi
+
+  echo ">> Installing Istio"
+  echo "Istio version: ${ISTIO_VERSION}"
+  echo "Istio profile: ${ISTIO_PROFILE}"
+  ${NET_ISTIO_DIR}/third_party/istio-${ISTIO_VERSION}/install-istio.sh ${ISTIO_PROFILE}
+}
+
 function knative_setup() {
+  if is_ingress_class istio; then
+    install_istio
+  fi
   start_latest_knative_serving
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

- Installs Istio (ever since the istio addon stopped being supported, Istio hasn't been installed). The [recent probe additions to net-istio](https://github.com/knative-sandbox/net-istio/pull/1095) probably caused the tests to fail because Istio wasn't installed.
- Follows the same flow used by [knative/client](https://github.com/knative/client/blob/main/test/common.sh#L32)

Fixes #290 
Related issue #269 