### PR TITLE
include additional k8s bash file when updating exec permission

### DIFF
--- a/codegen-library.sh
+++ b/codegen-library.sh
@@ -32,4 +32,5 @@ export CODEGEN_PKG=${CODEGEN_PKG:-$(cd ${REPO_ROOT_DIR}; ls -d -1 ./vendor/k8s.i
 export KNATIVE_CODEGEN_PKG=${KNATIVE_CODEGEN_PKG:-$(cd ${REPO_ROOT_DIR}; ls -d -1 ./vendor/knative.dev/pkg 2>/dev/null || echo "${REPO_ROOT_DIR}")}
 
 [ -x ${CODEGEN_PKG}/generate-groups.sh ] || chmod +x ${CODEGEN_PKG}/generate-groups.sh
+[ -x ${CODEGEN_PKG}/generate-internal-groups.sh ] || chmod +x ${CODEGEN_PKG}/generate-internal-groups.sh
 [ -x ${KNATIVE_CODEGEN_PKG}/hack/generate-knative.sh ] || chmod +x ${KNATIVE_CODEGEN_PKG}/hack/generate-knative.sh


### PR DESCRIPTION
There have been changes to the codegen scripts in k8s - we now need to add an exec bit to the following file

```
k8s.io/code-generator/generate-internal-groups.sh
```