### PR TITLE
Don't hardcode serving as the repo when setting highest semver

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -676,7 +676,7 @@ function set_latest_to_highest_semver() {
   fi
   
   hub_tool api --method PATCH "/repos/${ORG_NAME}/${REPO_NAME}/releases/$release_id" \
-    -F make_latest=true > /dev/null || abort "error settomg $last_version to 'latest'"
+    -F make_latest=true > /dev/null || abort "error setting $last_version to 'latest'"
   echo "Github release ${last_version} set as 'latest'"
 }
 

--- a/release.sh
+++ b/release.sh
@@ -675,7 +675,7 @@ function set_latest_to_highest_semver() {
     abort "cannot get relase id from github"
   fi
   
-  hub_tool api --method PATCH "/repos/knative/serving/releases/$release_id" \
+  hub_tool api --method PATCH "/repos/${ORG_NAME}/${REPO_NAME}/releases/$release_id" \
     -F make_latest=true > /dev/null || abort "error settomg $last_version to 'latest'"
   echo "Github release ${last_version} set as 'latest'"
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

Fixes errors like:
```
Setting latest release to highest semver
exit status 22
**************************************************
**** ERROR: error settomg v1.13.0 to 'latest' ****
************************************************** 
```
in the release jobs
# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Don't hardcode serving, use env variables instead

