### PR TITLE
drop toolchain directive

### DIFF
--- a/library.sh
+++ b/library.sh
@@ -748,6 +748,8 @@ function __go_update_deps_for_module() {
   orig_pipefail_opt=$(shopt -p -o pipefail)
   set -o pipefail
   go mod tidy 2>&1 | grep -v "ignoring symlink" || true
+  go get toolchain@none
+
   if [[ "${FORCE_VENDOR:-false}" == "true" ]] || [ -d vendor ]; then
     group "Go mod vendor"
     go mod vendor 2>&1 |  grep -v "ignoring symlink" || true


### PR DESCRIPTION
Toolchain directive isn't necessary - and it's breaking go-licenses.

This is a workaround that drops it when updating dependencies.