### PR TITLE
Set default for GKE version to 1.28

### DIFF
--- a/infra-library.sh
+++ b/infra-library.sh
@@ -19,6 +19,10 @@
 
 source "$(dirname "${BASH_SOURCE[0]:-$0}")/library.sh"
 
+# Default Kubernetes version to use for GKE, if not overridden with
+# the `--cluster-version` parameter.
+readonly GKE_DEFAULT_CLUSTER_VERSION="1.28"
+
 # Dumps the k8s api server metrics. Spins up a proxy, waits a little bit and
 # dumps the metrics to ${ARTIFACTS}/k8s.metrics.txt
 function dump_metrics() {
@@ -148,6 +152,9 @@ function create_gke_test_cluster() {
   fi
   if [[ ! " ${_custom_flags[*]} " =~ "--machine-type=" ]]; then
       _custom_flags+=("--machine-type=e2-standard-4")
+  fi
+  if [[ ! " ${_custom_flags[*]} " =~ "--cluster-version=" ]]; then
+      _custom_flags+=("--cluster-version=${GKE_DEFAULT_CLUSTER_VERSION}")
   fi
   kubetest2 gke "${_custom_flags[@]}" \
     --rundir-in-artifacts \


### PR DESCRIPTION
Currently we use the GKE default version for our GKE test clusters (https://cloud.google.com/kubernetes-engine/docs/release-notes-nochannel).
This can lead to problems when GKEs version is behind Knatives defined [min Kubernetes version](https://github.com/knative/pkg/blob/main/version/version.go#L36) and if repositories don't set it via the `--cluster-version` parameter.

This PR addresses it, and sets a Knative default for GKE test clusters.
Unfortunately this comes with the cost of maintaining this version - but can be reverted, when GKE uses a more recent version as default again.