### PR TITLE
:broom: Check licenses only, but not bundle them

### DIFF
--- a/library.sh
+++ b/library.sh
@@ -770,8 +770,8 @@ function __go_update_deps_for_module() {
     remove_broken_symlinks ./vendor
   fi
 
-  group "Updating licenses"
-  update_licenses third_party/VENDOR-LICENSE "./..."
+  group "Checking licenses"
+  check_licenses
   )
 }
 
@@ -805,18 +805,6 @@ function go_mod_gopath_hack() {
 # Parameters: $1..$n - parameters passed to the tool.
 function run_kntest() {
   go_run knative.dev/test-infra/tools/kntest/cmd/kntest@latest "$@"
-}
-
-# Run go-licenses to update licenses.
-# Parameters: $1 - output file, relative to repo root dir.
-#             $2 - directory to inspect.
-function update_licenses() {
-  local dst=$1
-  local dir=$2
-  shift
-  go_run github.com/google/go-licenses@v1.6.0 \
-    save "${dir}" --save_path="${dst}" --force || \
-    { echo "--- FAIL: go-licenses failed to update licenses"; return 1; }
 }
 
 # Run go-licenses to check for forbidden licenses.

--- a/test/unit/update_deps_test.go
+++ b/test/unit/update_deps_test.go
@@ -22,12 +22,11 @@ func TestUpdateDeps(t *testing.T) {
 			contains("Golang module: knative.dev/hack/test"),
 			contains("Golang module: knative.dev/hack/schema"),
 			contains("Golang module: knative.dev/hack"),
-			contains("Updating licenses"),
+			contains("Checking licenses"),
 			contains("Removing unwanted vendor files"),
 			contains("go mod tidy"),
 			contains("go mod vendor"),
-			contains("go run github.com/google/go-licenses@v1.6.0 save ./... " +
-				"--save_path=third_party/VENDOR-LICENSE --force"),
+			contains("go run github.com/google/go-licenses@v1.6.0 check"),
 		},
 	}, {
 		name: "go_update_deps --upgrade",


### PR DESCRIPTION
# Changes

- :broom: Check licenses only, but not bundle them

/kind cleanup

Fixes knative/community#1441

**Release Note**

```release-note
License files are no longer bundled with Knative sources, but only checked for validity
```