### PR TITLE
Tag images using ko

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -694,6 +694,8 @@ function main() {
   (( SKIP_TESTS )) && echo "- Tests will NOT be run" || echo "- Tests will be run"
   if (( TAG_RELEASE )); then
     echo "- Artifacts will be tagged '${TAG}'"
+    # We want to add git tags to the container images built by ko
+    KO_FLAGS+=" --tags=latest,${TAG}"
   else
     echo "- Artifacts WILL NOT be tagged"
   fi


### PR DESCRIPTION
#389 introduced a bug. The code I deleted in that PR was adding the git tags to the docker images. Now the git tag is passed to ko directly.

Tested with operator at https://console.cloud.google.com/artifacts/docker/knative-nightly/us/gcr.io/knative.dev%2Foperator%2Fcmd%2Foperator?project=knative-nightly