### PR TITLE
Enforce go-licenses v1.0.0

### DIFF
--- a/library.sh
+++ b/library.sh
@@ -918,7 +918,7 @@ function run_kntest() {
 # Run go-licenses to check for forbidden licenses.
 function check_licenses() {
   # Check that we don't have any forbidden licenses.
-  go_run github.com/google/go-licenses@v1.6.0 \
+  go_run github.com/google/go-licenses@v1.0.0 \
     check "${REPO_ROOT_DIR}/..." || \
     { echo "--- FAIL: go-licenses failed the license check"; return 1; }
 }

--- a/test/unit/update_deps_test.go
+++ b/test/unit/update_deps_test.go
@@ -29,7 +29,7 @@ func TestUpdateDeps(t *testing.T) {
 			contains("Checking licenses"),
 			contains("Removing unwanted vendor files"),
 			contains("👻 go mod tidy"),
-			contains("👻 go run github.com/google/go-licenses@v1.6.0 check"),
+			contains("👻 go run github.com/google/go-licenses@v1.0.0 check"),
 			contains("👻 go mod download -x"),
 		},
 	}, {


### PR DESCRIPTION
This should fixes issues we are getting with `go.mod` files containing the `toolchain` directive.

See google/go-licenses#128.

