### PR TITLE
Fix premature codegen cleanup exit on 1

### DIFF
--- a/codegen-library.sh
+++ b/codegen-library.sh
@@ -133,17 +133,20 @@ function restore-changes-if-its-copyright-year-only() {
   local difflist
   log "Cleaning up generated code"
   difflist="$(mktemp)"
-  git diff --exit-code --name-only > "$difflist"
-  # list git changes and skip those which differ only in the boilerplate year
-  while read -r file; do
-    # check if the file contains just the change in the boilerplate year
-    if [ "$(LANG=C git diff --exit-code --shortstat -- "$file")" = ' 1 file changed, 1 insertion(+), 1 deletion(-)' ] && \
-        [[ "$(git diff --exit-code -U1 -- "$file" | grep -Ec '^[+-]\s*[*#]?\s*Copyright 2[0-9]{3}')" -eq 2 ]]; then
-      # restore changes to that file
-      git checkout -- "$file"
-    fi
-  done < "$difflist"
-  rm -f "$difflist"
+  if ! git diff --exit-code --name-only > /dev/null; then
+    # list git changes and skip those which differ only in the boilerplate year
+    git diff --name-only > "$difflist"  
+    while read -r file; do
+      # check if the file contains just the change in the boilerplate year
+      if [ "$(LANG=C git diff --exit-code --shortstat -- "$file")" = ' 1 file changed, 1 insertion(+), 1 deletion(-)' ] && \
+          [[ "$(git diff --exit-code -U1 -- "$file" | grep -Ec '^[+-]\s*[*#]?\s*Copyright 2[0-9]{3}')" -eq 2 ]]; then
+        # restore changes to that file
+        git checkout -- "$file"
+      fi
+    done < "$difflist"
+    rm -f "$difflist"
+  fi
+  log "Cleanup done"
 }
 
 # Restore the GOPATH and clean up the temporary directory

--- a/codegen-library.sh
+++ b/codegen-library.sh
@@ -144,8 +144,8 @@ function restore-changes-if-its-copyright-year-only() {
         git checkout -- "$file"
       fi
     done < "$difflist"
-    rm -f "$difflist"
   fi
+  rm -f "$difflist"
 }
 
 # Restore the GOPATH and clean up the temporary directory

--- a/codegen-library.sh
+++ b/codegen-library.sh
@@ -146,7 +146,6 @@ function restore-changes-if-its-copyright-year-only() {
     done < "$difflist"
     rm -f "$difflist"
   fi
-  log "Cleanup done"
 }
 
 # Restore the GOPATH and clean up the temporary directory

--- a/library.sh
+++ b/library.sh
@@ -774,7 +774,7 @@ function go_update_deps() {
 function __clean_goworksum_if_exists() {
   if [ -f "$REPO_ROOT_DIR/go.work.sum" ]; then
     log.step 'Cleaning the go.work.sum file'
-    truncate --size 0 "$REPO_ROOT_DIR/go.work.sum"
+    truncate -s 0 "$REPO_ROOT_DIR/go.work.sum"
   fi
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Fix premature codegen cleanup exit on 1
- Fix `truncate` param to be macos compatible

/cc @skonto @cardil 