### PR TITLE
Bump default GKE version to 1.31

### DIFF
--- a/infra-library.sh
+++ b/infra-library.sh
@@ -21,7 +21,7 @@ source "$(dirname "${BASH_SOURCE[0]:-$0}")/library.sh"
 
 # Default Kubernetes version to use for GKE, if not overridden with
 # the `--cluster-version` parameter.
-readonly GKE_DEFAULT_CLUSTER_VERSION="1.30"
+readonly GKE_DEFAULT_CLUSTER_VERSION="1.31"
 
 # Dumps the k8s api server metrics. Spins up a proxy, waits a little bit and
 # dumps the metrics to ${ARTIFACTS}/k8s.metrics.txt


### PR DESCRIPTION
As per title, needed for 1.18 (https://github.com/knative/pkg/blob/ae2c6bcc1f5968766febc343903819b43d7ec903/version/version.go#L36)