### PR TITLE
[release-1.16] Update GKE version to 1.29

### DIFF
--- a/infra-library.sh
+++ b/infra-library.sh
@@ -21,7 +21,7 @@ source "$(dirname "${BASH_SOURCE[0]:-$0}")/library.sh"
 
 # Default Kubernetes version to use for GKE, if not overridden with
 # the `--cluster-version` parameter.
-readonly GKE_DEFAULT_CLUSTER_VERSION="1.28"
+readonly GKE_DEFAULT_CLUSTER_VERSION="1.29"
 
 # Dumps the k8s api server metrics. Spins up a proxy, waits a little bit and
 # dumps the metrics to ${ARTIFACTS}/k8s.metrics.txt


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- [release-1.16] Update GKE version to 1.29

Let's make sure we are able to run prow check on GKE. 

Fixes the following:
```
W0220 08:47:29.741775    4590 up.go:180] error resolving the release channel for "1.28": selected unknown release channel: EXTENDED, will proceed with no channel
Default change: VPC-native is the default mode during cluster creation for versions greater than 1.21.0-gke.1500. To create advanced routes based clusters, please pass the `--no-enable-ip-alias` flag
Default change: During creation of nodepools or autoscaling configuration changes for cluster versions greater than 1.24.1-gke.800 a default location policy is applied. For Spot and PVM it defaults to ANY, and for all other VM kinds a BALANCED policy is used. To change the default values use the `--location-policy` flag.
```

/cc @upodroid @cardil @dprotaso 