### PR TITLE
:wastebasket: Deprecate knative.dev/hack/schema

### DIFF
--- a/schema/README.md
+++ b/schema/README.md
@@ -1,5 +1,9 @@
 # Schema Tool
 
+> [!WARNING]  
+> This module is now deprecated. Please, use [k8s controller-gen](sigs.k8s.io/controller-tools/cmd/controller-gen) 
+> instead. See, example: https://github.com/knative-extensions/sample-controller/pull/931
+
 Schema is a seed of a CLI tool that a downstream can use to use reflection and go file inspection to 
 generate a base version of OpenAPI for a CRD. The resulting schema will be used by Kubernetes to
 provide results from `kubectl explain <type>` calls, and type validation.

--- a/schema/go.mod
+++ b/schema/go.mod
@@ -1,3 +1,4 @@
+// Deprecated: use k8s controller-gen instead, see: https://github.com/knative-extensions/sample-controller/pull/931
 module knative.dev/hack/schema
 
 go 1.21


### PR DESCRIPTION
# Changes

- :wastebasket: Deprecate knative.dev/hack/schema

/kind deprecation

Related https://github.com/knative/toolbox/pull/38
Related https://github.com/knative-extensions/sample-controller/pull/931

**Release Note**

```release-note
The knative.dev/hack/schema package is now deprecated. Please use K8s' controller-gen instead.
```