### PR TITLE
fix check_licenses GOTOOLCHAIN mismatch with go-licenses

### DIFF
--- a/library.sh
+++ b/library.sh
@@ -922,7 +922,10 @@ function run_kntest() {
 
 # Run go-licenses to check for forbidden licenses.
 function check_licenses() {
-  # Check that we don't have any forbidden licenses.
+  # Pin GOTOOLCHAIN to the project's Go version so that go-licenses is
+  # compiled with the same toolchain.  GOTOOLCHAIN=auto (the go_run default)
+  # may select a different Go, causing isStdLib() path mismatches.
+  GOTOOLCHAIN="$(go env GOVERSION)" \
   go_run github.com/google/go-licenses/v2@v2.0.1 \
     check "${REPO_ROOT_DIR}/..." || \
     { echo "--- FAIL: go-licenses failed the license check"; return 1; }


### PR DESCRIPTION
`check_licenses()` can fail when `GOTOOLCHAIN=auto` causes `go-licenses` to
be built with a different toolchain than the project, resulting in stdlib
packages being misidentified.

Fix by pinning `GOTOOLCHAIN` to `$(go env GOVERSION)` in `check_licenses()`.