### PR TITLE
Bump go-licenses to v2.0.1 release

### DIFF
--- a/library.sh
+++ b/library.sh
@@ -923,7 +923,7 @@ function run_kntest() {
 # Run go-licenses to check for forbidden licenses.
 function check_licenses() {
   # Check that we don't have any forbidden licenses.
-  go_run github.com/google/go-licenses@v1.6.0 \
+  go_run github.com/google/go-licenses/v2@v2.0.1 \
     check "${REPO_ROOT_DIR}/..." || \
     { echo "--- FAIL: go-licenses failed the license check"; return 1; }
 }

--- a/test/unit/update_deps_test.go
+++ b/test/unit/update_deps_test.go
@@ -29,7 +29,7 @@ func TestUpdateDeps(t *testing.T) {
 			contains("Checking licenses"),
 			contains("Removing unwanted vendor files"),
 			contains("👻 go mod tidy"),
-			contains("👻 go run github.com/google/go-licenses@v1.6.0 check"),
+			contains("👻 go run github.com/google/go-licenses/v2@v2.0.1 check"),
 			contains("👻 go mod download -x"),
 		},
 	}, {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Bump go-licenses to v2.0.1 release
  - API/ cmd structure is the same
  - Execution time seems improved a bit

The latest available release (even though from last year): https://github.com/google/go-licenses/releases/tag/v2.0.1

/cc @creydr @dprotaso @cardil 