### PR TITLE
Fix create kind test cluster args

### DIFF
--- a/e2e-tests.sh
+++ b/e2e-tests.sh
@@ -54,10 +54,14 @@ function setup_test_cluster() {
   header "Setting up test cluster"
   kubectl get nodes
 
-  # Set the actual project the test cluster resides in
-  # It will be a project assigned by Boskos if test is running on Prow,
-  # otherwise will be ${E2E_GCP_PROJECT_ID} set up by user.
-  E2E_PROJECT_ID="$(gcloud config get-value project)"
+  # Set the actual project the test cluster resides in. For GKE this
+  # comes from the Boskos-configured gcloud context; for other
+  # providers (e.g. kind) it is not meaningful and is left empty.
+  if [[ "${CLOUD_PROVIDER}" == "gke" ]]; then
+    E2E_PROJECT_ID="$(gcloud config get-value project)"
+  else
+    E2E_PROJECT_ID=""
+  fi
   export E2E_PROJECT_ID
   readonly E2E_PROJECT_ID
 

--- a/infra-library.sh
+++ b/infra-library.sh
@@ -84,7 +84,8 @@ function dump_cluster_state() {
 # Create a test cluster and run the tests if provided.
 # Parameters: $1 - cluster provider name, e.g. gke
 #             $2 - custom flags supported by kntest
-#             $3 - test command to run after cluster is created
+#             $3 - extra gcloud flags (gke only)
+#             $4 - test command to run after cluster is created
 function create_test_cluster() {
   # Fail fast during setup.
   set -o errexit
@@ -96,7 +97,7 @@ function create_test_cluster() {
 
   case "$1" in
     gke) create_gke_test_cluster "$2" "$3" "$4" "${5:-}" ;;
-    kind) create_kind_test_cluster "$2" "$3" "${4:-}" ;;
+    kind) create_kind_test_cluster "$2" "${4:-}" ;;
     *) echo "unsupported provider: $1"; exit 1 ;;
   esac
 

--- a/test/e2e-kind.sh
+++ b/test/e2e-kind.sh
@@ -46,18 +46,42 @@ function install_istio() {
       && git checkout FETCH_HEAD
   )
 
+  echo "Resolved net-istio release: ${LATEST_NET_ISTIO_RELEASE_VERSION}"
+  echo "net-istio commit SHA: $(git -C "${NET_ISTIO_DIR}" rev-parse HEAD)"
+
   if [[ -z "${ISTIO_PROFILE:-}" ]]; then
-    readonly ISTIO_PROFILE="istio-ci-no-mesh.yaml"
+    readonly ISTIO_PROFILE="istio-ci-no-mesh"
+  fi
+  # Accept legacy ISTIO_PROFILE values with a trailing .yaml suffix.
+  # Use a local because ISTIO_PROFILE is readonly once set above.
+  local istio_profile="${ISTIO_PROFILE%.yaml}"
+  local istio_dir="${NET_ISTIO_DIR}/third_party/istio-${ISTIO_VERSION}/${istio_profile}"
+
+  if [[ ! -d "${istio_dir}" ]]; then
+    echo "Istio profile directory not found: ${istio_dir}" >&2
+    return 1
   fi
 
   if [[ -n "${CLUSTER_DOMAIN:-}" ]]; then
-    sed -ie "s/cluster\.local/${CLUSTER_DOMAIN}/g" ${NET_ISTIO_DIR}/third_party/istio-${ISTIO_VERSION}/${ISTIO_PROFILE}
+    find "${istio_dir}" -type f -name '*.yaml' -print0 \
+      | xargs -0 sed -i.bak -e "s#cluster\.local#${CLUSTER_DOMAIN}#g"
+    # Clean up the .bak files left behind by sed -i.bak so that any future
+    # "kubectl apply -f <dir>" passes do not trip over them.
+    find "${istio_dir}" -type f -name '*.yaml.bak' -delete
   fi
 
   echo ">> Installing Istio"
   echo "Istio version: ${ISTIO_VERSION}"
-  echo "Istio profile: ${ISTIO_PROFILE}"
-  ${NET_ISTIO_DIR}/third_party/istio-${ISTIO_VERSION}/install-istio.sh ${ISTIO_PROFILE}
+  echo "Istio profile: ${istio_profile}"
+  kubectl apply -f "${istio_dir}" || {
+    echo "Failed to apply Istio manifests from ${istio_dir}" >&2
+    return 1
+  }
+
+  wait_until_pods_running istio-system || {
+    echo "Istio pods in istio-system did not become ready" >&2
+    return 1
+  }
 }
 
 function knative_setup() {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

<!--
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes

- :bug: Forward the test command to `kubetest2 kind` in `create_test_cluster` so the kind path actually runs the tester instead of spinning up a cluster and exiting 0.
- :bug: Skip the `gcloud config get-value project` lookup in `setup_test_cluster` unless `CLOUD_PROVIDER` is `gke`, so the kind path works without gcloud installed.
- :bug: Rewrite `install_istio` in `test/e2e-kind.sh` to apply net-istio's rendered profile directory with `kubectl apply -f`. The previous code invoked `third_party/istio-${ISTIO_VERSION}/install-istio.sh`, which no longer exists in net-istio releases.

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind bug

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

The `kind-tests_hack_main` presubmit has been reporting green since 2022-09 without actually running the tests it was supposed to execute. For the most recent green run, see [build-log.txt](https://storage.googleapis.com/knative-prow/pr-logs/pull/knative_hack/460/kind-tests_hack_main/2021710487644803072/build-log.txt) around line 240: `kubetest2 --test=exec --` prints its usage and kubetest2 exits 0 with no test ever invoked. Locally reproducing the same behavior and then applying this PR unblocks real hub e2e runs.

<img width="1028" height="516" alt="CleanShot 2026-04-15 at 20 53 26@2x" src="https://github.com/user-attachments/assets/9f5901a5-aa4a-4b9a-8424-4cfcd8e9d542" />

Once the first two fixes let `kind-tests_hack_main` actually run, a second latent bug surfaced: `install_istio` pointed at a script net-istio no longer ships, so Istio was never installed and `net-istio-controller` crash-looped. Failing run: https://prow.knative.dev/view/gs/knative-prow/pr-logs/pull/knative_hack/466/kind-tests_hack_main/2044382746704351232

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Fix the `kind` cloud-provider path so kubetest2's exec tester is actually invoked, skip the gcloud project lookup when the provider is not GKE, and update `install_istio` to apply net-istio's rendered Istio profile directory directly.
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
