### PR TITLE
Add env var to pass extra flag to license check, parametrize tool ver…

### DIFF
--- a/library.sh
+++ b/library.sh
@@ -35,6 +35,13 @@ if [[ ! -v GOPATH ]]; then
   fi
 fi
 
+# Pinned tool versions
+readonly GUM_VERSION="v0.14.1"
+readonly GOTESTSUM_VERSION="v1.13.0"
+readonly GOTESTFMT_VERSION="v2.5.0"
+readonly TERMINAL_TO_HTML_VERSION="v3.10.0"
+readonly GO_LICENSES_VERSION="v2.0.1"
+
 # Useful environment variables
 [[ -v PROW_JOB_ID ]] && IS_PROW=1 || IS_PROW=0
 readonly IS_PROW
@@ -265,7 +272,7 @@ function gum_banner() {
 
 # Simple info banner for logging purposes.
 function gum_style() {
-  go_run github.com/charmbracelet/gum@v0.14.1 style "$@"
+  go_run "github.com/charmbracelet/gum@${GUM_VERSION}" style "$@"
 }
 
 # Checks whether the given function exists.
@@ -588,7 +595,7 @@ function report_go_test() {
   logfile="${logfile/.xml/.jsonl}"
   echo "Running go test with args: ${go_test_args[*]}"
   local gotest_retcode=0
-  go_run gotest.tools/gotestsum@v1.13.0 \
+  go_run "gotest.tools/gotestsum@${GOTESTSUM_VERSION}" \
     --format "${GO_TEST_VERBOSITY:-testname}" \
     --junitfile "${xml}" \
     --junitfile-testsuite-name relative \
@@ -601,14 +608,14 @@ function report_go_test() {
   echo "Test log (JSONL) written to ${logfile}"
 
   ansilog="${logfile/.jsonl/-ansi.log}"
-  go_run github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@v2.5.0 \
+  go_run "github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@${GOTESTFMT_VERSION}" \
     -input "${logfile}" \
     -showteststatus \
     -nofail > "$ansilog"
   echo "Test log (ANSI) written to ${ansilog}"
 
   htmllog="${logfile/.jsonl/.html}"
-  go_run github.com/buildkite/terminal-to-html/v3/cmd/terminal-to-html@v3.10.0 \
+  go_run "github.com/buildkite/terminal-to-html/v3/cmd/terminal-to-html@${TERMINAL_TO_HTML_VERSION}" \
     --preview < "$ansilog" > "$htmllog"
   echo "Test log (HTML) written to ${htmllog}"
 
@@ -921,13 +928,14 @@ function run_kntest() {
 }
 
 # Run go-licenses to check for forbidden licenses.
+# Extra flags can be passed via the GO_LICENSES_FLAGS environment variable.
 function check_licenses() {
   # Pin GOTOOLCHAIN to the project's Go version so that go-licenses is
   # compiled with the same toolchain.  GOTOOLCHAIN=auto (the go_run default)
   # may select a different Go, causing isStdLib() path mismatches.
   GOTOOLCHAIN="$(go env GOVERSION)" \
-  go_run github.com/google/go-licenses/v2@v2.0.1 \
-    check "${REPO_ROOT_DIR}/..." || \
+  go_run "github.com/google/go-licenses/v2@${GO_LICENSES_VERSION}" \
+    check ${GO_LICENSES_FLAGS:-} "${REPO_ROOT_DIR}/..." || \
     { echo "--- FAIL: go-licenses failed the license check"; return 1; }
 }
 


### PR DESCRIPTION
…sions

<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Add env var to pass extra flag to license check
- Parametrize tool versions


After `go-licenses` v2 the following error is present in repos using `gotest.tools` library. The issue is license format, that was previously recognized in v1 (v1 check passes) as header type, and I think it should be the case for v2. The `go-licenses` is currently unmaintained, so we can either stick with v1 version or keep using v2 with an extra flags `--ignore` when needed.  

I'll open an issue with them.

v1: https://github.com/google/go-licenses/blob/v1.6.0/licenses/classifier.go#L95-L98
v2: https://github.com/google/go-licenses/blob/v2.0.1/licenses/classifier.go#L69-L71
Adding the following fixes the issue:
```
if match.MatchType != "License" &&  match.MatchType != "Header" {
```


https://github.com/gotestyourself/gotest.tools/blob/main/LICENSE
```
  Did not find license for library 'gotest.tools/v3/assert'.
  Did not find license for library 'gotest.tools/v3/assert/cmp'.
  Did not find license for library 'gotest.tools/v3/internal/assert'.
  Did not find license for library 'gotest.tools/v3/internal/format'.
  Did not find license for library 'gotest.tools/v3/internal/source'.

```

Consuming repo example: 
```
# Library gotest.tools/v3 which has a short-form Apache 2.0 notice
# that go-licenses v2 fails to classify.
export GO_LICENSES_FLAGS="--ignore gotest.tools/v3"
```

Client PR: https://github.com/knative/client/pull/2191


/cc @dprotaso 