### PR TITLE
Remove deprecated go get -d flag

### DIFF
--- a/library.sh
+++ b/library.sh
@@ -838,7 +838,7 @@ function __go_update_deps_for_module() {
     FLOATING_DEPS+=( $(go_run knative.dev/toolbox/buoy@latest float ./go.mod "${buoyArgs[@]}") )
     if [[ ${#FLOATING_DEPS[@]} > 0 ]]; then
       echo "Floating deps to ${FLOATING_DEPS[@]}"
-      go get -d ${FLOATING_DEPS[@]}
+      go get ${FLOATING_DEPS[@]}
     else
       echo "Nothing to upgrade."
     fi


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Remove deprecated go get -d flag

Currently there's harmless warning (2 years+), that might never become an issue, but let's clean it up. 

```
=== Update Deps for Golang module: knative.dev/eventing
--- Upgrading to release 1.21
Floating deps to knative.dev/hack@release-1.21 knative.dev/hack/schema@release-1.21 knative.dev/pkg@release-1.21 knative.dev/reconciler-test@release-1.21
go: -d flag is deprecated. -d=true is a no-op
```

/cc @dprotaso 